### PR TITLE
docs: add about page

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -3,5 +3,7 @@ description: "Insights and resources from Learn Language Education Academy"
 baseurl: "" # the subpath of your site, e.g. /blog
 url: "https://blog.falowen.app" # your custom domain
 theme: minima
+header_pages:
+  - about.md
 plugins:
   - jekyll-feed

--- a/about.md
+++ b/about.md
@@ -1,0 +1,8 @@
+---
+layout: page
+title: About
+permalink: /about/
+---
+
+Falowen shares insights and resources to support language education.
+Our mission is to empower learners everywhere to connect through language.


### PR DESCRIPTION
## Summary
- add About page describing Falowen's mission
- surface About in Minima navigation

## Testing
- `jekyll build` *(fails: command not found)*
- `gem install jekyll` *(fails: 403 Forbidden)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68c07aa10c548321a56388d88e4f6026