### PR TITLE
Add site-wide head include with meta tags

### DIFF
--- a/_includes/head-custom.html
+++ b/_includes/head-custom.html
@@ -1,0 +1,23 @@
+{% if page.excerpt %}
+<meta name="description" content="{{ page.excerpt | strip_html | strip_newlines | truncate: 160 }}">
+{% elsif site.description %}
+<meta name="description" content="{{ site.description | escape }}">
+{% endif %}
+
+<link rel="icon" href="{{ '/favicon.ico' | relative_url }}">
+
+<meta property="og:title" content="{{ page.title | default: site.title | escape }}">
+<meta property="og:description" content="{{ page.excerpt | strip_html | strip_newlines | truncate: 160 | default: site.description | escape }}">
+<meta property="og:url" content="{{ page.url | absolute_url }}">
+<meta property="og:site_name" content="{{ site.title | escape }}">
+<meta property="og:type" content="website">
+
+{% if site.google_analytics %}
+<script async src="https://www.googletagmanager.com/gtag/js?id={{ site.google_analytics }}"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+  gtag('config', '{{ site.google_analytics }}');
+</script>
+{% endif %}


### PR DESCRIPTION
## Summary
- add new `_includes/head-custom.html` for meta description, favicon, and open‑graph tags
- include optional Google Analytics snippet tied to `site.google_analytics`

## Testing
- `bundle exec jekyll build` *(fails: Could not locate Gemfile or .bundle/ directory)*

------
https://chatgpt.com/codex/tasks/task_e_68c07b452a38832195e9ed0ae0fdf34a