### PR TITLE
ci: build Jekyll site

### DIFF
--- a/workflows/ci.yml
+++ b/workflows/ci.yml
@@ -5,18 +5,14 @@ on:
   pull_request:
 
 jobs:
-  test:
+  build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-ruby@v1
         with:
-          python-version: '3.11'
+          ruby-version: '3.1'
       - name: Install dependencies
-        run: |
-          pip install --upgrade pip
-          pip install -r requirements.txt
-      - name: Run linter
-        run: flake8 .
-      - name: Run tests
-        run: pytest
+        run: bundle install
+      - name: Build site
+        run: bundle exec jekyll build


### PR DESCRIPTION
## Summary
- replace Python workflow with Ruby Jekyll build

## Testing
- `bundle install` *(fails: Gem::Net::HTTPClientException 403 "Forbidden")*
- `bundle exec jekyll build` *(fails: bundler: command not found: jekyll)*

------
https://chatgpt.com/codex/tasks/task_e_68c07bf8085883218bb3587b8fbc597f