### PR TITLE
Add Gemfile for Jekyll site

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,6 @@
+source "https://rubygems.org"
+
+gem "jekyll", "~> 4.3"
+gem "minima", "~> 2.5"
+gem "jekyll-feed"
+gem "jekyll-seo-tag"


### PR DESCRIPTION
## Summary
- add Gemfile specifying Jekyll and related plugins

## Testing
- `bundle install` *(fails: Gem::Net::HTTPClientException 403 "Forbidden")*
- `bundle exec jekyll build` *(fails: bundler: command not found: jekyll)*

------
https://chatgpt.com/codex/tasks/task_e_68c07d9b3da48321b241023f5202500a