### PR TITLE
Configure site navigation and SEO

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -5,5 +5,11 @@ url: "https://blog.falowen.app" # your custom domain
 theme: minima
 header_pages:
   - about.md
+  - search.md
+  - categories.md
+  - tags.md
 plugins:
   - jekyll-feed
+  - jekyll-seo-tag
+twitter_username: falowen
+github_username: falowen


### PR DESCRIPTION
## Summary
- expose About, Search, Categories, and Tags pages in site header
- enable jekyll-seo-tag for better metadata
- add Twitter and GitHub handles for SEO

## Testing
- `bundle install` *(fails: Gem::Net::HTTPClientException 403 "Forbidden")*
- `bundle exec jekyll build` *(command not found: jekyll)*

------
https://chatgpt.com/codex/tasks/task_e_68c080b687008321ad6a800fbbe51e5a