### PR TITLE
Add German conversation partner blog post

### DIFF
--- a/_posts/2024-09-10-falowen-your-german-conversation-partner.md
+++ b/_posts/2024-09-10-falowen-your-german-conversation-partner.md
@@ -1,0 +1,30 @@
+---
+layout: post
+title: "Falowen: Your German Conversation Partner for Everyday Learning"
+date: 2024-09-10
+tags: [falowen, german, learning]
+excerpt: "How Falowen bridges classroom study and daily German practice."
+---
+
+## The Story Behind Falowen
+Falowen started as a side project to keep classroom lessons alive after the bell rings. It grew into a friendly chat companion that keeps German fresh in your mind through casual conversation.
+
+## What Makes Falowen Different?
+- Available anytime you want to practice.
+- Gives feedback in plain language, not grammar jargon.
+- Remembers what you've learned and builds on it.
+- Keeps sessions short so they fit easily into your day.
+
+## Why Falowen Matters
+Regular conversation turns vocabulary into something you can actually use. Falowen offers:
+- A safe place to make mistakes.
+- Gentle nudges to help you express yourself naturally.
+- Encouragement that builds confidence with every chat.
+
+## The Bigger Vision
+Falowen is part of a wider mission to make language practice feel like a daily habit rather than homework. We see a future where learners connect through stories, culture, and curiosity—not just quizzes.
+
+## Get Started Today
+- Sign in at [falowen.app](https://falowen.app).
+- Start a conversation about your day.
+- See how a few minutes can transform your learning routine.


### PR DESCRIPTION
## Summary
- add "Falowen: Your German Conversation Partner for Everyday Learning" blog post

## Testing
- `bundle install` (fails: Gem::Net::HTTPClientException 403 "Forbidden")
- `bundle exec jekyll build` (fails: bundler: command not found: jekyll)


------
https://chatgpt.com/codex/tasks/task_e_68c0837891988321852245043a8280d1