### PR TITLE
Fix DOCTYPE and update favicon

### DIFF
--- a/_includes/head-custom.html
+++ b/_includes/head-custom.html
@@ -4,7 +4,7 @@
 <meta name="description" content="{{ site.description | escape }}">
 {% endif %}
 
-<link rel="icon" href="{{ '/favicon.ico' | relative_url }}">
+<link rel="icon" href="https://i.imgur.com/mcrrGfd.png" />
 
 <meta property="og:title" content="{{ page.title | default: site.title | escape }}">
 <meta property="og:description" content="{{ page.excerpt | strip_html | strip_newlines | truncate: 160 | default: site.description | escape }}">

--- a/index.md
+++ b/index.md
@@ -2,7 +2,7 @@
 layout: null
 ---
 
-<!doctype html>
+<!DOCTYPE html>
 <html lang="en">
 <head>
   <meta charset="utf-8">


### PR DESCRIPTION
## Summary
- Use uppercase `<!DOCTYPE html>` in index template
- Update site favicon to `https://i.imgur.com/mcrrGfd.png`

## Testing
- `bundle exec jekyll build` *(fails: command not found: jekyll)*
- `bundle install` *(fails: Gem::Net::HTTPClientException 403 "Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68c08c93e9308321ba0a4602d7285dc4