### PR TITLE
Add register link to top navigation

### DIFF
--- a/index.md
+++ b/index.md
@@ -78,6 +78,7 @@ layout: null
       <a href="{{ '/search/' | relative_url }}">Search</a>
       <a href="{{ '/categories/' | relative_url }}">Categories</a>
       <a href="{{ '/tags/' | relative_url }}">Tags</a>
+      <a href="https://register.falowen.app" target="_blank" rel="noopener">Register</a>
     </nav>
   </div>
 


### PR DESCRIPTION
## Summary
- add Register external link to top navigation bar

## Testing
- `bundle install` *(fails: Gem::Net::HTTPClientException 403 'Forbidden')*
- `bundle exec jekyll build` *(fails: bundler: command not found: jekyll)*

------
https://chatgpt.com/codex/tasks/task_e_68c0973f915883218ec369c848a4a75e