### PR TITLE
Add reusable top navigation and custom header

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,0 +1,28 @@
+<header class="site-header" role="banner">
+  {% include topnav.html %}
+  <div class="wrapper">
+    <a class="site-title" rel="author" href="{{ '/' | relative_url }}">{{ site.title | escape }}</a>
+    {% assign default_paths = site.pages | map: 'path' %}
+    {% assign page_paths = site.header_pages | default: default_paths %}
+    {% if page_paths %}
+      <nav class="site-nav">
+        <input type="checkbox" id="nav-trigger" class="nav-trigger" />
+        <label for="nav-trigger">
+          <span class="menu-icon">
+            <svg viewBox="0 0 18 15" width="18" height="15">
+              <path d="M18,1.484c0,0.82-0.665,1.484-1.484,1.484H1.484C0.665,2.969,0,2.304,0,1.484 C0,0.665,0.665,0,1.484,0h15.031C17.335,0,18,0.665,18,1.484z M18,7.516 c0,0.82-0.665,1.484-1.484,1.484H1.484C0.665,9,0,8.335,0,7.516 c0-0.82,0.665-1.484,1.484-1.484h15.031C17.335,6.031,18,6.696,18,7.516z M18,13.547 c0,0.82-0.665,1.484-1.484,1.484H1.484C0.665,15.031,0,14.367,0,13.547 c0-0.82,0.665-1.484,1.484-1.484h15.031C17.335,12.062,18,12.727,18,13.547z"/>
+            </svg>
+          </span>
+        </label>
+        <div class="trigger">
+          {% for path in page_paths %}
+            {% assign my_page = site.pages | where: 'path', path | first %}
+            {% if my_page.title %}
+              <a class="page-link" href="{{ my_page.url | relative_url }}">{{ my_page.title | escape }}</a>
+            {% endif %}
+          {% endfor %}
+        </div>
+      </nav>
+    {% endif %}
+  </div>
+</header>

--- a/_includes/topnav.html
+++ b/_includes/topnav.html
@@ -1,0 +1,15 @@
+<style>
+  .topnav{display:flex;gap:14px;align-items:center;justify-content:flex-end;padding:10px 0}
+  .topnav a{color:#25317e;text-decoration:none;font-weight:700}
+  .topnav a:hover{text-decoration:underline}
+</style>
+<div class="wrap">
+  <nav class="topnav">
+    <a href="{{ '/' | relative_url }}">Home</a>
+    <a href="{{ '/about/' | relative_url }}">About</a>
+    <a href="{{ '/search/' | relative_url }}">Search</a>
+    <a href="{{ '/categories/' | relative_url }}">Categories</a>
+    <a href="{{ '/tags/' | relative_url }}">Tags</a>
+    <a href="https://register.falowen.app" target="_blank" rel="noopener">Register</a>
+  </nav>
+</div>

--- a/index.md
+++ b/index.md
@@ -63,24 +63,12 @@ layout: null
       font-size:13px;color:#324051;text-decoration:none;background:#fff
     }
     footer{border-top:1px solid var(--line);padding:18px 0;color:#475569}
-    .topnav{display:flex;gap:14px;align-items:center;justify-content:flex-end;padding:10px 0}
-    .topnav a{color:var(--brand);text-decoration:none;font-weight:700}
-    .topnav a:hover{text-decoration:underline}
   </style>
 </head>
 <body>
 
   <!-- Top nav (optional quick links) -->
-  <div class="wrap">
-    <nav class="topnav">
-      <a href="{{ '/' | relative_url }}">Home</a>
-      <a href="{{ '/about/' | relative_url }}">About</a>
-      <a href="{{ '/search/' | relative_url }}">Search</a>
-      <a href="{{ '/categories/' | relative_url }}">Categories</a>
-      <a href="{{ '/tags/' | relative_url }}">Tags</a>
-      <a href="https://register.falowen.app" target="_blank" rel="noopener">Register</a>
-    </nav>
-  </div>
+  {% include topnav.html %}
 
   <!-- Hero -->
   <header class="hero">


### PR DESCRIPTION
## Summary
- create reusable `_includes/topnav.html` partial with quick links
- replace inline navigation in `index.md` with the new include
- override Minima header to include top navigation for pages and posts

## Testing
- `bundle install` *(fails: Gem::Net::HTTPClientException 403 "Forbidden")*
- `bundle exec jekyll build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c09abcb3fc8321aaa22648170c54cd