### PR TITLE
Add Giscus-based comments

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -16,3 +16,11 @@ plugins:
 paginate: 10
 twitter_username: falowen
 github_username: falowen
+
+giscus:
+  repo: "owner/repo"
+  repo_id: "YOUR_REPO_ID"
+  category: "General"
+  category_id: "YOUR_CATEGORY_ID"
+  theme: light
+  lang: en

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -1,0 +1,40 @@
+---
+layout: default
+---
+
+<article class="post h-entry" itemscope itemtype="http://schema.org/BlogPosting">
+  <header class="post-header">
+    <h1 class="post-title p-name" itemprop="name headline">{{ page.title | escape }}</h1>
+    <p class="post-meta">
+      <time class="dt-published" datetime="{{ page.date | date_to_xmlschema }}" itemprop="datePublished">
+        {{ page.date | date: "%b %-d, %Y" }}
+      </time>
+      {%- if page.author -%}
+        • <span class="p-author h-card" itemprop="author">{{ page.author }}</span>
+      {%- endif -%}
+    </p>
+  </header>
+
+  <div class="post-content e-content" itemprop="articleBody">
+    {{ content }}
+  </div>
+
+  <section id="comments">
+    <div id="giscus_thread"></div>
+    <script src="https://giscus.app/client.js"
+            data-repo="{{ site.giscus.repo }}"
+            data-repo-id="{{ site.giscus.repo_id }}"
+            data-category="{{ site.giscus.category }}"
+            data-category-id="{{ site.giscus.category_id }}"
+            data-mapping="pathname"
+            data-reactions-enabled="1"
+            data-emit-metadata="0"
+            data-input-position="bottom"
+            data-theme="{{ site.giscus.theme | default: 'light' }}"
+            data-lang="{{ site.giscus.lang | default: 'en' }}"
+            crossorigin="anonymous"
+            async>
+    </script>
+    <noscript>Please enable JavaScript to view the comments powered by Giscus.</noscript>
+  </section>
+</article>


### PR DESCRIPTION
## Summary
- add Giscus configuration placeholders in `_config.yml`
- create `post` layout embedding Giscus comment widget

## Testing
- `bundle exec jekyll build` *(fails: bundler: command not found: jekyll)*

------
https://chatgpt.com/codex/tasks/task_e_68c09d4f3c508321bf835d986762f7ab