### PR TITLE
Add newsletter subscription form

### DIFF
--- a/_includes/newsletter.html
+++ b/_includes/newsletter.html
@@ -1,0 +1,10 @@
+<section class="newsletter">
+  <div class="wrap">
+    <h2>Join our newsletter</h2>
+    <form action="https://example.us1.list-manage.com/subscribe/post?u=0000000000000000000000000&id=0000000000" method="post" target="_blank" novalidate class="newsletter-form">
+      <label class="sr-only" for="mce-EMAIL">Email address</label>
+      <input type="email" value="" name="EMAIL" id="mce-EMAIL" placeholder="Email address" required>
+      <button type="submit" name="subscribe">Subscribe</button>
+    </form>
+  </div>
+</section>

--- a/index.md
+++ b/index.md
@@ -62,6 +62,13 @@ layout: null
       display:inline-block;border:1px solid var(--line);padding:6px 10px;border-radius:999px;
       font-size:13px;color:#324051;text-decoration:none;background:#fff
     }
+    .newsletter{background:var(--bg);border-top:1px solid var(--line);padding:32px 0;text-align:center}
+    .newsletter h2{margin:0 0 12px 0;font-size:24px;color:var(--ink)}
+    .newsletter-form{display:flex;flex-wrap:wrap;gap:8px;justify-content:center}
+    .newsletter-form input[type=email]{border:1px solid var(--line);border-radius:8px;padding:10px 14px;font-size:16px}
+    .newsletter-form button{background:var(--brand);color:#fff;border:1px solid rgba(37,49,126,.9);border-radius:8px;padding:10px 16px;font-weight:700}
+    .newsletter-form button:hover{filter:brightness(1.05)}
+    .sr-only{position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0}
     footer{border-top:1px solid var(--line);padding:18px 0;color:#475569}
   </style>
 </head>
@@ -131,6 +138,8 @@ layout: null
       {% endif %}
     </nav>
   </section>
+
+  {% include newsletter.html %}
 
   <footer>
     <div class="wrap">


### PR DESCRIPTION
## Summary
- add reusable newsletter signup partial with Mailchimp-style form
- inject newsletter include into index page and style with existing design variables

## Testing
- `bundle exec jekyll build` *(fails: bundler: command not found: jekyll)*
- `bundle install` *(fails: Gem::Net::HTTPClientException 403 "Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68c09f547f9c83218235e9e81245db2b