### PR TITLE
feat: render post images

### DIFF
--- a/_includes/post-card.html
+++ b/_includes/post-card.html
@@ -1,6 +1,9 @@
 {% assign p = include.post %}
 <article class="post-card">
   <a class="post-card-link" href="{{ p.url | relative_url }}">
+    {% if p.image %}
+    <img class="post-card-img" src="{{ p.image }}" alt="{{ p.title }}" />
+    {% endif %}
     <h3 class="post-card-title">{{ p.title }}</h3>
     {% if p.excerpt %}
       <p class="post-card-excerpt">{{ p.excerpt | strip_html | truncate: 110 }}</p>
@@ -22,4 +25,5 @@
 .post-card-excerpt{margin:0 0 8px 0;color:#475569}
 .post-card-meta{font-size:.9rem;color:#64748b}
 .post-card-link{color:inherit;text-decoration:none}
+.post-card-img{width:100%;height:auto;border-radius:8px;margin-bottom:8px;display:block}
 </style>

--- a/index.md
+++ b/index.md
@@ -56,6 +56,7 @@ layout: null
     .card a{color:inherit;text-decoration:none}
     .card h3{margin:0;color:var(--ink);font-size:18px}
     .card p{margin:0;color:var(--muted);font-size:15px}
+    .post-card-img{width:100%;height:auto;border-radius:12px;margin-bottom:8px;display:block}
     .meta{font-size:13px;color:#8a97ab}
     .actions{display:flex;gap:10px;flex-wrap:wrap;margin-top:8px}
     .pill{
@@ -111,6 +112,9 @@ layout: null
       {% for post in paginator.posts %}
       <article class="card">
         <a href="{{ post.url | relative_url }}">
+          {% if post.image %}
+          <img class="post-card-img" src="{{ post.image }}" alt="{{ post.title }}" />
+          {% endif %}
           <h3>{{ post.title }}</h3>
           {% if post.excerpt %}
           <p>{{ post.excerpt | strip_html | truncate: 120 }}</p>


### PR DESCRIPTION
## Summary
- render post featured images on cards when `post.image` is set
- add `post-card-img` styling for responsive thumbnails

## Testing
- `bundle exec jekyll build` *(fails: jekyll: command not found)*
- `bundle install` *(fails: Gem::Net::HTTPClientException 403 "Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68c0a021ef7c832188a9239c552caff0