### PR TITLE
Add related posts include

### DIFF
--- a/_includes/related-posts.html
+++ b/_includes/related-posts.html
@@ -1,0 +1,32 @@
+{% assign related_posts = '' | split: '' %}
+{% if page.tags %}
+  {% for tag in page.tags %}
+    {% assign posts = site.tags[tag] %}
+    {% if posts %}
+      {% assign related_posts = related_posts | concat: posts %}
+    {% endif %}
+  {% endfor %}
+{% elsif page.categories %}
+  {% for category in page.categories %}
+    {% assign posts = site.categories[category] %}
+    {% if posts %}
+      {% assign related_posts = related_posts | concat: posts %}
+    {% endif %}
+  {% endfor %}
+{% endif %}
+{% assign related_posts = related_posts | uniq | where_exp: 'post', 'post.url != page.url' | slice: 0, 3 %}
+{% if related_posts.size > 0 %}
+<section class="related-posts">
+  <h2>Related Posts</h2>
+  <ul>
+  {% for post in related_posts %}
+    <li><a href="{{ post.url | relative_url }}">{{ post.title }}</a></li>
+  {% endfor %}
+  </ul>
+</section>
+{% else %}
+<section class="related-posts">
+  <h2>Related Posts</h2>
+  <p>No related posts found.</p>
+</section>
+{% endif %}

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -37,4 +37,5 @@ layout: default
     </script>
     <noscript>Please enable JavaScript to view the comments powered by Giscus.</noscript>
   </section>
+  {% include related-posts.html %}
 </article>


### PR DESCRIPTION
## Summary
- add related posts include that loops through tags or categories and limits to three entries with fallback text
- include related posts section at the bottom of the post layout

## Testing
- `bundle install` *(fails: 403 Forbidden fetching gems)*
- `bundle exec jekyll build` *(fails: missing `jekyll` executable)*

------
https://chatgpt.com/codex/tasks/task_e_68c0a0f89b788321a707d24e1dd6fba2