### PR TITLE
chore: remove twitter handle from site config

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -14,7 +14,7 @@ plugins:
   - jekyll-sitemap
   - jekyll-paginate
 paginate: 10
-twitter_username: falowen
+# twitter_username: falowen
 github_username: falowen
 
 giscus:


### PR DESCRIPTION
## Summary
- stop setting Twitter username so footer won't show Twitter icon

## Testing
- `bundle exec jekyll build` *(fails: bundler: command not found: jekyll)*
- `bundle install` *(fails: Gem::Net::HTTPClientException 403 "Forbidden" installing gems)*


------
https://chatgpt.com/codex/tasks/task_e_68c0a3734c7c8321bdf4df90b4fcff0a