### PR TITLE
Add theme toggle and extract styles

### DIFF
--- a/_includes/topnav.html
+++ b/_includes/topnav.html
@@ -1,8 +1,3 @@
-<style>
-  .topnav{display:flex;gap:14px;align-items:center;justify-content:flex-end;padding:10px 0}
-  .topnav a{color:#25317e;text-decoration:none;font-weight:700}
-  .topnav a:hover{text-decoration:underline}
-</style>
 <div class="wrap">
   <nav class="topnav">
     <a href="{{ '/' | relative_url }}">Home</a>
@@ -11,5 +6,6 @@
     <a href="{{ '/categories/' | relative_url }}">Categories</a>
     <a href="{{ '/tags/' | relative_url }}">Tags</a>
     <a href="https://register.falowen.app" target="_blank" rel="noopener">Register</a>
+    <button id="theme-toggle" type="button">Toggle theme</button>
   </nav>
 </div>

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -1,0 +1,61 @@
+:root{
+  --brand:#25317e;
+  --bg:#f3f7fb;
+  --ink:#1c2440;
+  --muted:#64748b;
+  --card:#ffffff;
+  --ring:rgba(37,49,126,.18);
+  --line:rgba(148,163,184,.35);
+}
+@media (prefers-color-scheme: dark){
+  :root{
+    --bg:#0b1022;
+    --ink:#f3f7fb;
+    --muted:#94a3b8;
+    --card:#1e293b;
+    --ring:rgba(37,49,126,.4);
+    --line:rgba(148,163,184,.3);
+  }
+}
+body.light{
+  --bg:#f3f7fb;
+  --ink:#1c2440;
+  --muted:#64748b;
+  --card:#ffffff;
+  --ring:rgba(37,49,126,.18);
+  --line:rgba(148,163,184,.35);
+}
+body.dark{
+  --bg:#0b1022;
+  --ink:#f3f7fb;
+  --muted:#94a3b8;
+  --card:#1e293b;
+  --ring:rgba(37,49,126,.4);
+  --line:rgba(148,163,184,.3);
+}
+html,body{margin:0;padding:0;background:var(--bg);color:var(--ink);font-family:system-ui,-apple-system,Segoe UI,Roboto,Inter,Helvetica,Arial,sans-serif}
+.wrap{max-width:1100px;margin:0 auto;padding:0 18px}
+.hero{background:linear-gradient(180deg,var(--bg),rgba(243,247,251,0));border-top:6px solid var(--brand);padding:44px 0 22px}
+.hero h1{margin:0 0 10px 0;font-size:clamp(28px,4vw,44px);line-height:1.1;color:var(--ink);font-weight:900}
+.hero p{margin:0 0 16px 0;color:var(--muted);font-size:clamp(16px,2vw,18px)}
+.cta{display:inline-block;background:var(--brand);color:#fff;text-decoration:none;padding:12px 16px;border-radius:12px;font-weight:800;border:1px solid rgba(37,49,126,.9);box-shadow:0 10px 22px var(--ring)}
+.cta:hover{filter:brightness(1.05)}
+.features{display:grid;grid-template-columns:repeat(auto-fit,minmax(220px,1fr));gap:12px;margin:18px 0 8px}
+.feature{background:var(--card);border:1px solid var(--line);border-radius:14px;padding:14px 16px;box-shadow:0 6px 14px rgba(2,6,23,.06)}
+.feature h3{margin:0 0 6px 0;font-size:18px;color:var(--ink)}
+.feature p{margin:0;color:var(--muted);font-size:15px}
+.section{padding:10px 0 28px}
+.section h2{margin:8px 0 10px 0;color:var(--ink);font-size:24px}
+.grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(260px,1fr));gap:14px;align-items:stretch}
+.card{background:var(--card);border:1px solid var(--line);border-radius:14px;padding:14px 16px;box-shadow:0 6px 14px rgba(2,6,23,.06);display:flex;flex-direction:column;gap:8px}
+.card a{color:inherit;text-decoration:none}
+.card h3{margin:0;color:var(--ink);font-size:18px}
+.card p{margin:0;color:var(--muted);font-size:15px}
+.meta{font-size:13px;color:var(--muted)}
+.actions{display:flex;gap:10px;flex-wrap:wrap;margin-top:8px}
+.pill{display:inline-block;border:1px solid var(--line);padding:6px 10px;border-radius:999px;font-size:13px;color:var(--ink);text-decoration:none;background:var(--card)}
+.topnav{display:flex;gap:14px;align-items:center;justify-content:flex-end;padding:10px 0}
+.topnav a{color:var(--brand);text-decoration:none;font-weight:700}
+.topnav a:hover{text-decoration:underline}
+#theme-toggle{background:none;border:1px solid var(--line);padding:6px 10px;border-radius:999px;font-size:13px;color:var(--ink);cursor:pointer}
+footer{border-top:1px solid var(--line);padding:18px 0;color:var(--muted)}

--- a/index.md
+++ b/index.md
@@ -11,59 +11,7 @@ layout: null
   {%- comment -%} Minima head + your custom head {%- endcomment -%}
   {%- include head.html -%}
   {%- include head-custom.html -%}
-  <style>
-    :root{
-      --brand:#25317e;
-      --bg:#f3f7fb;
-      --ink:#1c2440;
-      --muted:#64748b;
-      --card:#ffffff;
-      --ring:rgba(37,49,126,.18);
-      --line:rgba(148,163,184,.35);
-    }
-    html,body{margin:0;padding:0;background:#fff;color:#0b1022;font-family:system-ui,-apple-system,Segoe UI,Roboto,Inter,Helvetica,Arial,sans-serif}
-    .wrap{max-width:1100px;margin:0 auto;padding:0 18px}
-    .hero{
-      background: linear-gradient(180deg, var(--bg), rgba(243,247,251,0));
-      border-top: 6px solid var(--brand);
-      padding: 44px 0 22px;
-    }
-    .hero h1{margin:0 0 10px 0;font-size: clamp(28px, 4vw, 44px);line-height:1.1;color:var(--ink);font-weight:900}
-    .hero p{margin:0 0 16px 0;color:var(--muted);font-size: clamp(16px, 2vw, 18px)}
-    .cta{
-      display:inline-block;background:var(--brand);color:#fff;text-decoration:none;
-      padding:12px 16px;border-radius:12px;font-weight:800;border:1px solid rgba(37,49,126,.9);
-      box-shadow:0 10px 22px var(--ring);
-    }
-    .cta:hover{filter:brightness(1.05)}
-    .features{display:grid;grid-template-columns:repeat(auto-fit,minmax(220px,1fr));gap:12px;margin:18px 0 8px}
-    .feature{
-      background:var(--card); border:1px solid var(--line); border-radius:14px; padding:14px 16px;
-      box-shadow:0 6px 14px rgba(2,6,23,.06)
-    }
-    .feature h3{margin:0 0 6px 0; font-size:18px; color:var(--ink)}
-    .feature p{margin:0;color:var(--muted);font-size:15px}
-    .section{padding: 10px 0 28px}
-    .section h2{margin:8px 0 10px 0;color:var(--ink);font-size:24px}
-    .grid{
-      display:grid;grid-template-columns:repeat(auto-fill,minmax(260px,1fr));
-      gap:14px;align-items:stretch
-    }
-    .card{
-      background:#fff;border:1px solid var(--line);border-radius:14px;padding:14px 16px;
-      box-shadow:0 6px 14px rgba(2,6,23,.06);display:flex;flex-direction:column;gap:8px
-    }
-    .card a{color:inherit;text-decoration:none}
-    .card h3{margin:0;color:var(--ink);font-size:18px}
-    .card p{margin:0;color:var(--muted);font-size:15px}
-    .meta{font-size:13px;color:#8a97ab}
-    .actions{display:flex;gap:10px;flex-wrap:wrap;margin-top:8px}
-    .pill{
-      display:inline-block;border:1px solid var(--line);padding:6px 10px;border-radius:999px;
-      font-size:13px;color:#324051;text-decoration:none;background:#fff
-    }
-    footer{border-top:1px solid var(--line);padding:18px 0;color:#475569}
-  </style>
+  <link rel="stylesheet" href="{{ '/assets/css/main.css' | relative_url }}">
 </head>
 <body>
 
@@ -143,6 +91,20 @@ layout: null
       · <a href="https://register.falowen.app" target="_blank" rel="noopener">Register</a>
     </div>
   </footer>
-
+  <script>
+    (function() {
+      const toggle = document.getElementById('theme-toggle');
+      const stored = localStorage.getItem('theme');
+      const prefers = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+      const theme = stored || prefers;
+      document.body.classList.add(theme);
+      toggle.addEventListener('click', function() {
+        const next = document.body.classList.contains('dark') ? 'light' : 'dark';
+        document.body.classList.remove('light', 'dark');
+        document.body.classList.add(next);
+        localStorage.setItem('theme', next);
+      });
+    })();
+  </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- move inline index styles into `assets/css/main.css`
- define light/dark color variables and auto-theme via `prefers-color-scheme`
- add top‑nav button with JS toggle persisting choice

## Testing
- `bundle install` *(fails: Gem::Net::HTTPClientException 403 "Forbidden")*
- `bundle exec jekyll build` *(fails: bundler: command not found: jekyll)*

------
https://chatgpt.com/codex/tasks/task_e_68c09f13fd9c83219fba661b58fa6669