### PR TITLE
Add site header and footer includes

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,11 +1,12 @@
-<footer>
+<footer class="site-footer">
   <div class="wrap">
-    © {{ site.time | date: "%Y" }} Learn Language Education Academy
-    · <a href="mailto:learngermanghana@gmail.com">learngermanghana@gmail.com</a>
-    · <a href="https://instagram.com/lleaghana" target="_blank" rel="noopener">Instagram</a>
-    · <a href="https://tiktok.com/@lleaghana" target="_blank" rel="noopener">TikTok</a>
-    · <a href="https://youtube.com/@LLEAGhana" target="_blank" rel="noopener">YouTube</a>
-    · <a href="https://linkedin.com/in/lleaghana" target="_blank" rel="noopener">LinkedIn</a>
-    · <a href="https://register.falowen.app" target="_blank" rel="noopener">Register</a>
+    <p>© {{ site.time | date: "%Y" }} Learn Language Education Academy</p>
+    <p>
+      <a href="mailto:learngermanghana@gmail.com">Contact</a>
+      · <a href="https://instagram.com/lleaghana" target="_blank" rel="noopener">Instagram</a>
+      · <a href="https://tiktok.com/@lleaghana" target="_blank" rel="noopener">TikTok</a>
+      · <a href="https://youtube.com/@LLEAGhana" target="_blank" rel="noopener">YouTube</a>
+      · <a href="https://linkedin.com/in/lleaghana" target="_blank" rel="noopener">LinkedIn</a>
+    </p>
   </div>
 </footer>

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,28 +1,16 @@
-<header class="site-header" role="banner">
-  {% include topnav.html %}
-  <div class="wrapper">
-    <a class="site-title" rel="author" href="{{ '/' | relative_url }}">{{ site.title | escape }}</a>
-    {% assign default_paths = site.pages | map: 'path' %}
-    {% assign page_paths = site.header_pages | default: default_paths %}
-    {% if page_paths %}
-      <nav class="site-nav">
-        <input type="checkbox" id="nav-trigger" class="nav-trigger" />
-        <label for="nav-trigger">
-          <span class="menu-icon">
-            <svg viewBox="0 0 18 15" width="18" height="15">
-              <path d="M18,1.484c0,0.82-0.665,1.484-1.484,1.484H1.484C0.665,2.969,0,2.304,0,1.484 C0,0.665,0.665,0,1.484,0h15.031C17.335,0,18,0.665,18,1.484z M18,7.516 c0,0.82-0.665,1.484-1.484,1.484H1.484C0.665,9,0,8.335,0,7.516 c0-0.82,0.665-1.484,1.484-1.484h15.031C17.335,6.031,18,6.696,18,7.516z M18,13.547 c0,0.82-0.665,1.484-1.484,1.484H1.484C0.665,15.031,0,14.367,0,13.547 c0-0.82,0.665-1.484,1.484-1.484h15.031C17.335,12.062,18,12.727,18,13.547z"/>
-            </svg>
-          </span>
-        </label>
-        <div class="trigger">
-          {% for path in page_paths %}
-            {% assign my_page = site.pages | where: 'path', path | first %}
-            {% if my_page.title %}
-              <a class="page-link" href="{{ my_page.url | relative_url }}">{{ my_page.title | escape }}</a>
-            {% endif %}
-          {% endfor %}
-        </div>
-      </nav>
-    {% endif %}
+<header class="site-header">
+  <div class="wrap">
+    <a class="logo" href="{{ '/' | relative_url }}">
+      <img src="{{ '/assets/images/logo.png' | relative_url }}" alt="{{ site.title }} logo">
+    </a>
+    <nav class="topnav">
+      <a href="{{ '/' | relative_url }}">Home</a>
+      <a href="{{ '/about/' | relative_url }}">About</a>
+      <a href="{{ '/search/' | relative_url }}">Search</a>
+      <a href="{{ '/categories/' | relative_url }}">Categories</a>
+      <a href="{{ '/tags/' | relative_url }}">Tags</a>
+      <a href="https://register.falowen.app" target="_blank" rel="noopener">Register</a>
+      <button id="theme-toggle" type="button">Toggle theme</button>
+    </nav>
   </div>
 </header>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -5,17 +5,17 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    {%- include head.html -%}
-    {%- include head-custom.html -%}
+    {% include head.html %}
+    {% include head-custom.html %}
     <link rel="stylesheet" href="{{ '/assets/css/main.css' | relative_url }}">
   </head>
   <body>
-    {%- include header.html -%}
+    {% include header.html %}
     <main class="page-content" aria-label="Content">
-      <div class="wrapper">
+      <div class="wrap">
         {{ content }}
       </div>
     </main>
-    {%- include footer.html -%}
+    {% include footer.html %}
   </body>
 </html>

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -12,7 +12,6 @@
   <link rel="stylesheet" href="{{ '/assets/css/main.css' | relative_url }}">
 </head>
 <body>
-
   {% include header.html %}
 
   <!-- Hero -->
@@ -82,7 +81,6 @@
   </section>
 
   {% include newsletter.html %}
-
   {% include footer.html %}
 
   <script>


### PR DESCRIPTION
## Summary
- Add a reusable header include with logo, navigation links, and theme toggle button.
- Add a footer include featuring contact information and social media links.
- Reference the new header and footer includes from the default and home layouts.

## Testing
- `bundle install` *(fails: Gem::Net::HTTPClientException 403 "Forbidden")*
- `bundle exec jekyll build` *(fails: bundler: command not found: jekyll)*

------
https://chatgpt.com/codex/tasks/task_e_68c0a88f72e88321b98d36f8174dbc00