### PR TITLE
feat: apply Inter font across site

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -1,3 +1,4 @@
+@import url("https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700;900&display=swap");
 :root{
   --brand:#25317e;
   --bg:#f3f7fb;
@@ -33,7 +34,9 @@ body.dark{
   --ring:rgba(37,49,126,.4);
   --line:rgba(148,163,184,.3);
 }
-html,body{margin:0;padding:0;background:var(--bg);color:var(--ink);font-family:system-ui,-apple-system,Segoe UI,Roboto,Inter,Helvetica,Arial,sans-serif}
+html,body{margin:0;padding:0;background:var(--bg);color:var(--ink);font-family:Inter,system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif;font-weight:400;line-height:1.6}
+h1,h2,h3,h4,h5,h6{font-family:Inter,system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif;font-weight:700;line-height:1.3}
+h1{font-weight:900;line-height:1.1}
 .wrap{max-width:1100px;margin:0 auto;padding:0 18px}
 .hero{background:linear-gradient(180deg,var(--bg),rgba(243,247,251,0));border-top:6px solid var(--brand);padding:44px 0 22px}
 .hero h1{margin:0 0 10px 0;font-size:clamp(28px,4vw,44px);line-height:1.1;color:var(--ink);font-weight:900}

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -1,6 +1,8 @@
 ---
 ---
 
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700;900&display=swap');
+
 $color-brand: #25317e;
 $color-background: #f3f7fb;
 $color-ink: #1c2440;
@@ -10,7 +12,7 @@ $color-ring: rgba(37,49,126,0.18);
 $color-line: rgba(148,163,184,0.35);
 
 $spacing-unit: 8px;
-$font-family-base: system-ui, -apple-system, "Segoe UI", Roboto, Inter, Helvetica, Arial, sans-serif;
+$font-family-base: 'Inter', system-ui, -apple-system, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
 
 :root {
   --brand: #{$color-brand};
@@ -26,9 +28,22 @@ html,
 body {
   margin: 0;
   padding: 0;
-  background: #fff;
-  color: #0b1022;
+  background: var(--bg);
+  color: var(--ink);
   font-family: $font-family-base;
+  font-weight: 400;
+  line-height: 1.6;
+}
+
+h1, h2, h3, h4, h5, h6 {
+  font-family: $font-family-base;
+  font-weight: 700;
+  line-height: 1.3;
+}
+
+h1 {
+  font-weight: 900;
+  line-height: 1.1;
 }
 
 .wrap {


### PR DESCRIPTION
## Summary
- import Inter from Google Fonts
- use Inter as default font for body and headings with hierarchy

## Testing
- `bundle exec jekyll build` *(fails: bundler: command not found: jekyll)*

------
https://chatgpt.com/codex/tasks/task_e_68c0aa3e1b488321be97d6cdf0c4abe8