### PR TITLE
Remove theme switcher and keep light default

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -10,7 +10,6 @@
       <a href="{{ '/categories/' | relative_url }}">Categories</a>
       <a href="{{ '/tags/' | relative_url }}">Tags</a>
       <a href="https://register.falowen.app" target="_blank" rel="noopener">Register</a>
-      <button id="theme-toggle" type="button">Toggle theme</button>
     </nav>
   </div>
 </header>

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -83,20 +83,5 @@
   {% include newsletter.html %}
   {% include footer.html %}
 
-  <script>
-    (function() {
-      const toggle = document.getElementById('theme-toggle');
-      const stored = localStorage.getItem('theme');
-      const prefers = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
-      const theme = stored || prefers;
-      document.body.classList.add(theme);
-      toggle.addEventListener('click', function() {
-        const next = document.body.classList.contains('dark') ? 'light' : 'dark';
-        document.body.classList.remove('light', 'dark');
-        document.body.classList.add(next);
-        localStorage.setItem('theme', next);
-      });
-    })();
-  </script>
-</body>
-</html>
+  </body>
+  </html>


### PR DESCRIPTION
## Summary
- remove header theme toggle button
- drop home page script that switched themes
- keep light color variables for default appearance

## Testing
- `bundle exec jekyll build` *(fails: bundler: command not found: jekyll)*
- `bundle install` *(fails: Gem::Net::HTTPClientException 403 "Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68c0ad4c3db0832185ce9cadba69c22e