### PR TITLE
Enable future-dated posts in Jekyll config

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -14,6 +14,7 @@ plugins:
   - jekyll-sitemap
   - jekyll-paginate
 paginate: 10
+future: true
 # twitter_username: falowen
 github_username: falowen
 


### PR DESCRIPTION
## Summary
- allow publishing posts with future dates by adding `future: true`

## Testing
- `bundle install` *(fails: Gem::Net::HTTPClientException 403 "Forbidden")*
- `bundle exec jekyll build` *(fails: bundler: command not found: jekyll)*


------
https://chatgpt.com/codex/tasks/task_e_68c0ad4ce9148321b1c92d4c21489a66