### PR TITLE
Ensure responsive scaling for images

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -35,6 +35,7 @@ body.dark{
   --line:rgba(148,163,184,.3);
 }
 html,body{margin:0;padding:0;background:var(--bg);color:var(--ink);font-family:Inter,system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif;font-weight:400;line-height:1.6}
+img{max-width:100%;height:auto}
 h1,h2,h3,h4,h5,h6{font-family:Inter,system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif;font-weight:700;line-height:1.3}
 h1{font-weight:900;line-height:1.1}
 .wrap{max-width:1100px;margin:0 auto;padding:0 18px}

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -35,6 +35,11 @@ body {
   line-height: 1.6;
 }
 
+img {
+  max-width: 100%;
+  height: auto;
+}
+
 h1, h2, h3, h4, h5, h6 {
   font-family: $font-family-base;
   font-weight: 700;


### PR DESCRIPTION
## Summary
- add global `img` rule for responsive images
- regenerate compiled CSS

## Testing
- `bundle install` *(fails: Gem::Net::HTTPClientException 403 "Forbidden")*
- `npx sass assets/css/main.scss assets/css/main.css` *(fails: 403 Forbidden)*
- `jekyll build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c0b2d8266c83219b4faf50c65b0d4e