### PR TITLE
Move topnav styles to SCSS source

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -58,8 +58,4 @@ h1{font-weight:900;line-height:1.1}
 .meta{font-size:13px;color:var(--muted)}
 .actions{display:flex;gap:10px;flex-wrap:wrap;margin-top:8px}
 .pill{display:inline-block;border:1px solid var(--line);padding:6px 10px;border-radius:999px;font-size:13px;color:var(--ink);text-decoration:none;background:var(--card)}
-.topnav{display:flex;gap:14px;align-items:center;justify-content:flex-end;padding:10px 0}
-.topnav a{color:var(--brand);text-decoration:none;font-weight:700}
-.topnav a:hover{text-decoration:underline}
-#theme-toggle{background:none;border:1px solid var(--line);padding:6px 10px;border-radius:999px;font-size:13px;color:var(--ink);cursor:pointer}
 footer{border-top:1px solid var(--line);padding:18px 0;color:var(--muted)}

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -196,6 +196,34 @@ h1 {
   background: #fff;
 }
 
+.topnav {
+  display: flex;
+  gap: 14px;
+  align-items: center;
+  justify-content: flex-end;
+  padding: 10px 0;
+}
+
+.topnav a {
+  color: var(--brand);
+  text-decoration: none;
+  font-weight: 700;
+}
+
+.topnav a:hover {
+  text-decoration: underline;
+}
+
+#theme-toggle {
+  background: none;
+  border: 1px solid var(--line);
+  padding: 6px 10px;
+  border-radius: 999px;
+  font-size: 13px;
+  color: var(--ink);
+  cursor: pointer;
+}
+
 .newsletter {
   background: var(--bg);
   border-top: 1px solid var(--line);


### PR DESCRIPTION
## Summary
- Add `.topnav` and `#theme-toggle` styling to SCSS so navigation styles are maintained in one place
- Remove duplicated `.topnav` styles from compiled CSS

## Testing
- ⚠️ `bundle exec jekyll build` *(missing jekyll gem)*

------
https://chatgpt.com/codex/tasks/task_e_68c0b3b16ad48321981e589a81533552