### PR TITLE
Remove accessibility attribute from main element

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -11,7 +11,7 @@
   </head>
   <body>
     {% include header.html %}
-    <main class="page-content" aria-label="Content">
+    <main class="page-content">
       <div class="wrap">
         {{ content }}
       </div>


### PR DESCRIPTION
## Summary
- remove `aria-label` from main page container to disable accessibility label

## Testing
- `bundle exec jekyll build` *(fails: jekyll executable not found)*
- `bundle install` *(fails: Gem::Net::HTTPClientException 403 "Forbidden" while fetching gems)*

------
https://chatgpt.com/codex/tasks/task_e_68c0b946034c8321a026c22074a3eced