### PR TITLE
Remove dark mode theme support

### DIFF
--- a/_includes/topnav.html
+++ b/_includes/topnav.html
@@ -6,6 +6,5 @@
     <a href="{{ '/categories/' | relative_url }}">Categories</a>
     <a href="{{ '/tags/' | relative_url }}">Tags</a>
     <a href="https://register.falowen.app" target="_blank" rel="noopener">Register</a>
-    <button id="theme-toggle" type="button">Toggle theme</button>
   </nav>
 </div>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -9,7 +9,7 @@
     {% include head-custom.html %}
     <link rel="stylesheet" href="{{ '/assets/css/main.css' | relative_url }}">
   </head>
-  <body>
+  <body class="light">
     {% include header.html %}
     <main class="page-content">
       <div class="wrap">

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -8,32 +8,6 @@
   --ring:rgba(37,49,126,.18);
   --line:rgba(148,163,184,.35);
 }
-@media (prefers-color-scheme: dark){
-  :root{
-    --bg:#0b1022;
-    --ink:#f3f7fb;
-    --muted:#94a3b8;
-    --card:#1e293b;
-    --ring:rgba(37,49,126,.4);
-    --line:rgba(148,163,184,.3);
-  }
-}
-body.light{
-  --bg:#f3f7fb;
-  --ink:#1c2440;
-  --muted:#64748b;
-  --card:#ffffff;
-  --ring:rgba(37,49,126,.18);
-  --line:rgba(148,163,184,.35);
-}
-body.dark{
-  --bg:#0b1022;
-  --ink:#f3f7fb;
-  --muted:#94a3b8;
-  --card:#1e293b;
-  --ring:rgba(37,49,126,.4);
-  --line:rgba(148,163,184,.3);
-}
 html,body{margin:0;padding:0;background:var(--bg);color:var(--ink);font-family:Inter,system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif;font-weight:400;line-height:1.6}
 img{max-width:100%;height:auto}
 h1,h2,h3,h4,h5,h6{font-family:Inter,system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif;font-weight:700;line-height:1.3}
@@ -58,4 +32,14 @@ h1{font-weight:900;line-height:1.1}
 .meta{font-size:13px;color:var(--muted)}
 .actions{display:flex;gap:10px;flex-wrap:wrap;margin-top:8px}
 .pill{display:inline-block;border:1px solid var(--line);padding:6px 10px;border-radius:999px;font-size:13px;color:var(--ink);text-decoration:none;background:var(--card)}
+.topnav{display:flex;gap:14px;align-items:center;justify-content:flex-end;padding:10px 0}
+.topnav a{color:var(--brand);text-decoration:none;font-weight:700}
+.topnav a:hover{text-decoration:underline}
+.newsletter{background:var(--bg);border-top:1px solid var(--line);padding:32px 0;text-align:center}
+.newsletter h2{margin:0 0 12px 0;font-size:24px;color:var(--ink)}
+.newsletter-form{display:flex;flex-wrap:wrap;gap:8px;justify-content:center}
+.newsletter-form input[type=email]{border:1px solid var(--line);border-radius:8px;padding:10px 14px;font-size:16px}
+.newsletter-form button{background:var(--brand);color:#fff;border:1px solid rgba(37,49,126,.9);border-radius:8px;padding:10px 16px;font-weight:700}
+.newsletter-form button:hover{filter:brightness(1.05)}
+.sr-only{position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0}
 footer{border-top:1px solid var(--line);padding:18px 0;color:var(--muted)}

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -214,16 +214,6 @@ h1 {
   text-decoration: underline;
 }
 
-#theme-toggle {
-  background: none;
-  border: 1px solid var(--line);
-  padding: 6px 10px;
-  border-radius: 999px;
-  font-size: 13px;
-  color: var(--ink);
-  cursor: pointer;
-}
-
 .newsletter {
   background: var(--bg);
   border-top: 1px solid var(--line);


### PR DESCRIPTION
## Summary
- Drop dark-mode overrides and theme toggle styles
- Force light palette by default and remove theme switch button

## Testing
- `bundle exec jekyll build` *(fails: bundler: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c0bab27ad48321aa5949031871cd1a