### PR TITLE
Add blogs page with full post listing and navigation link

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -6,6 +6,7 @@
       <a href="{{ '/search/' | relative_url }}">Search</a>
       <a href="{{ '/categories/' | relative_url }}">Categories</a>
       <a href="{{ '/tags/' | relative_url }}">Tags</a>
+      <a href="{{ '/blogs/' | relative_url }}">Blogs</a>
       <a href="https://register.falowen.app" target="_blank" rel="noopener">Register</a>
     </nav>
   </div>

--- a/_includes/topnav.html
+++ b/_includes/topnav.html
@@ -5,6 +5,7 @@
     <a href="{{ '/search/' | relative_url }}">Search</a>
     <a href="{{ '/categories/' | relative_url }}">Categories</a>
     <a href="{{ '/tags/' | relative_url }}">Tags</a>
+    <a href="{{ '/blogs/' | relative_url }}">Blogs</a>
     <a href="https://register.falowen.app" target="_blank" rel="noopener">Register</a>
   </nav>
 </div>

--- a/blogs.md
+++ b/blogs.md
@@ -1,0 +1,14 @@
+---
+layout: page
+title: Blogs
+permalink: /blogs/
+---
+
+<ul>
+{% for post in site.posts %}
+  <li>
+    <a href="{{ post.url | relative_url }}">{{ post.title }}</a>
+    <small>— {{ post.date | date: "%Y-%m-%d" }}</small>
+  </li>
+{% endfor %}
+</ul>


### PR DESCRIPTION
## Summary
- add new `blogs.md` page that lists all posts
- link to the new blogs page from header and top navigation

## Testing
- `bundle exec jekyll build` *(fails: bundler: command not found: jekyll)*
- `bundle install` *(fails: Gem::Net::HTTPClientException 403 "Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68c157f8989c8321b0c9c6f5842cb82e