### PR TITLE
Add post navigation and styles

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -19,6 +19,15 @@ layout: default
     {{ content }}
   </div>
 
+  <nav class="post-nav">
+    {% if page.previous %}
+      <a class="prev" href="{{ page.previous.url | relative_url }}">&laquo; {{ page.previous.title }}</a>
+    {% endif %}
+    {% if page.next %}
+      <a class="next" href="{{ page.next.url | relative_url }}">{{ page.next.title }} &raquo;</a>
+    {% endif %}
+  </nav>
+
   <section id="comments">
     <div id="giscus_thread"></div>
     <script src="https://giscus.app/client.js"

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -35,5 +35,8 @@ h1{font-weight:900;line-height:1.1}
 .topnav{display:flex;gap:14px;align-items:center;justify-content:flex-end;padding:10px 0}
 .topnav a{color:var(--brand);text-decoration:none;font-weight:700}
 .topnav a:hover{text-decoration:underline}
+.post-nav{display:flex;justify-content:space-between;margin:16px 0}
+.post-nav a{color:var(--brand);text-decoration:none;font-weight:700}
+.post-nav a:hover{text-decoration:underline}
 .sr-only{position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0}
 footer{border-top:1px solid var(--line);padding:18px 0;color:var(--muted)}

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -214,6 +214,22 @@ h1 {
   text-decoration: underline;
 }
 
+.post-nav {
+  display: flex;
+  justify-content: space-between;
+  margin: $spacing-unit * 2 0;
+}
+
+.post-nav a {
+  color: var(--brand);
+  text-decoration: none;
+  font-weight: 700;
+}
+
+.post-nav a:hover {
+  text-decoration: underline;
+}
+
 .sr-only {
   position: absolute;
   width: 1px;


### PR DESCRIPTION
## Summary
- add previous/next navigation links to post layout
- style post navigation in SCSS and compiled CSS

## Testing
- `bundle exec jekyll build` *(fails: bundler: command not found: jekyll; gem installation blocked by 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c1590fd5fc8321afbf362af7935a55