### PR TITLE
Use topnav include for site header navigation

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,13 +1,3 @@
 <header class="site-header">
-  <div class="wrap">
-    <nav class="topnav">
-      <a href="{{ '/' | relative_url }}">Home</a>
-      <a href="{{ '/about/' | relative_url }}">About</a>
-      <a href="{{ '/search/' | relative_url }}">Search</a>
-      <a href="{{ '/categories/' | relative_url }}">Categories</a>
-      <a href="{{ '/tags/' | relative_url }}">Tags</a>
-      <a href="{{ '/blogs/' | relative_url }}">Blogs</a>
-      <a href="https://register.falowen.app" target="_blank" rel="noopener">Register</a>
-    </nav>
-  </div>
+  {% include topnav.html %}
 </header>


### PR DESCRIPTION
## Summary
- Refactor header to include topnav partial
- Keep unified navigation links including Blogs entry

## Testing
- `bundle exec jekyll build` *(fails: bundler missing jekyll executable)*
- `bundle install` *(fails: Gem::Net::HTTPClientException 403 "Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68c15ac4e0e4832194ebcc73a5498f6a