### PR TITLE
Add feature icons to highlights section

### DIFF
--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -28,14 +28,17 @@
     <h2>Highlights</h2>
     <div class="features">
       <div class="feature">
+        <img src="{{ '/assets/img/exam.svg' | relative_url }}" alt="Exam icon">
         <h3>Exam-focused</h3>
         <p>Practical guidance aligned to Goethe A1–C1 tasks.</p>
       </div>
       <div class="feature">
+        <img src="{{ '/assets/img/vocab.svg' | relative_url }}" alt="Vocabulary icon">
         <h3>Vocabulary that sticks</h3>
         <p>Short examples and routines that build habits.</p>
       </div>
       <div class="feature">
+        <img src="{{ '/assets/img/teacher.svg' | relative_url }}" alt="Teacher and app icon">
         <h3>Teacher + App</h3>
         <p>Assignments, feedback, and daily practice in one place.</p>
       </div>

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -22,6 +22,7 @@ h1{font-weight:900;line-height:1.1}
 .feature{background:var(--card);border:1px solid var(--line);border-radius:14px;padding:14px 16px;box-shadow:0 6px 14px rgba(2,6,23,.06)}
 .feature h3{margin:0 0 6px 0;font-size:18px;color:var(--ink)}
 .feature p{margin:0;color:var(--muted);font-size:15px}
+.feature img{width:32px;margin-bottom:8px}
 .section{padding:10px 0 28px}
 .section h2{margin:8px 0 10px 0;color:var(--ink);font-size:24px}
 .grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(260px,1fr));gap:14px;align-items:stretch}

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -120,6 +120,11 @@ h1 {
   font-size: 15px;
 }
 
+.feature img {
+  width: 32px;
+  margin-bottom: $spacing-unit;
+}
+
 .section {
   padding: 10px 0 28px;
 }

--- a/assets/img/exam.svg
+++ b/assets/img/exam.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <rect x="3" y="3" width="18" height="18" rx="2"/>
+  <path d="m9 12 2 2 4-4"/>
+</svg>

--- a/assets/img/teacher.svg
+++ b/assets/img/teacher.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <circle cx="12" cy="7" r="4"/>
+  <path d="M6 21v-2a6 6 0 0 1 12 0v2"/>
+</svg>

--- a/assets/img/vocab.svg
+++ b/assets/img/vocab.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M4 19h8V5H4z"/>
+  <path d="M12 19h8V5h-8z"/>
+</svg>


### PR DESCRIPTION
## Summary
- add SVG icons to feature highlights on home page
- style feature icons for consistent sizing and spacing

## Testing
- `bundle exec jekyll build` *(fails: bundler: command not found: jekyll)*
- `bundle install` *(fails: Gem::Net::HTTPClientException 403 "Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68c1701841e88321b4eb941da686db9b