### PR TITLE
Remove extra footer include from home layout

### DIFF
--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -80,7 +80,5 @@
     </nav>
   </section>
 
-  {% include footer.html %}
-
   </body>
   </html>


### PR DESCRIPTION
## Summary
- remove duplicate `footer.html` include from `home` layout to rely on layout footer only

## Testing
- `bundle exec jekyll build` *(fails: bundler: command not found: jekyll)*

------
https://chatgpt.com/codex/tasks/task_e_68c17021aac88321b0a09d83edb9c7ea