### PR TITLE
Add testimonials section with Google Sheets-driven reviews

### DIFF
--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -45,6 +45,15 @@
     </div>
   </section>
 
+  <!-- Testimonials -->
+  <section id="testimonials" class="wrap section">
+    <h2>What students say</h2>
+    <div class="reviews-container">
+      <p>Loading testimonials...</p>
+    </div>
+    <noscript>Please enable JavaScript to view testimonials.</noscript>
+  </section>
+
   <!-- Latest posts grid -->
   <section class="wrap section">
     <h2>Latest articles</h2>
@@ -82,6 +91,8 @@
       {% endif %}
     </nav>
   </section>
+
+  <script type="module" src="{{ '/assets/js/reviews.js' | relative_url }}"></script>
 
   </body>
   </html>

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -41,3 +41,9 @@ h1{font-weight:900;line-height:1.1}
 .post-nav a:hover{text-decoration:underline}
 .sr-only{position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0}
 footer{border-top:1px solid var(--line);padding:18px 0;color:var(--muted)}
+#testimonials .reviews-container{display:grid;grid-template-columns:repeat(auto-fill,minmax(260px,1fr));gap:12px}
+.review-card{background:var(--card);border:1px solid var(--line);border-radius:14px;padding:14px 16px;box-shadow:0 6px 14px rgba(2,6,23,.06);animation:fadeIn .4s ease-in forwards}
+.review-card h3{margin:0 0 4px 0;font-size:16px;color:var(--ink)}
+.review-card .stars{color:#eab308;margin-bottom:8px;font-size:14px}
+.review-card p{margin:0;color:var(--muted);font-size:15px}
+@keyframes fadeIn{from{opacity:0;transform:translateY(10px)}to{opacity:1;transform:translateY(0)}}

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -253,3 +253,47 @@ footer {
   color: var(--muted);
 }
 
+#testimonials .reviews-container {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+  gap: $spacing-unit * 1.5;
+}
+
+.review-card {
+  background: var(--card);
+  border: 1px solid var(--line);
+  border-radius: 14px;
+  padding: 14px 16px;
+  box-shadow: 0 6px 14px rgba(2,6,23,.06);
+  animation: fadeIn 0.4s ease-in forwards;
+}
+
+.review-card h3 {
+  margin: 0 0 4px 0;
+  font-size: 16px;
+  color: var(--ink);
+}
+
+.review-card .stars {
+  color: #eab308;
+  margin-bottom: $spacing-unit;
+  font-size: 14px;
+}
+
+.review-card p {
+  margin: 0;
+  color: var(--muted);
+  font-size: 15px;
+}
+
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+    transform: translateY(10px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+

--- a/assets/js/reviews.js
+++ b/assets/js/reviews.js
@@ -1,0 +1,55 @@
+const SHEET_ID = '137HANmV9jmMWJEdcA1klqGiP8nYihkDugcIbA-2V1Wc';
+const SHEET_GID = '0'; // worksheet gid
+
+const endpoint = `https://docs.google.com/spreadsheets/d/${SHEET_ID}/gviz/tq?gid=${SHEET_GID}`;
+
+async function fetchReviews() {
+  const container = document.querySelector('#testimonials .reviews-container');
+  if (!container) return;
+  try {
+    const res = await fetch(endpoint);
+    const text = await res.text();
+    const json = JSON.parse(text.substring(47).slice(0, -2));
+    const rows = json.table.rows || [];
+    const reviews = rows.map(row => ({
+      student_name: row.c[0]?.v || '',
+      rating: Number(row.c[1]?.v) || 0,
+      review_text: row.c[2]?.v || ''
+    }));
+    if (reviews.length === 0) {
+      container.innerHTML = '<p>No testimonials yet.</p>';
+    } else {
+      renderReviews(reviews, container);
+    }
+  } catch (err) {
+    console.error('Failed to load reviews', err);
+    container.innerHTML = '<p class="error">Unable to load testimonials.</p>';
+  }
+}
+
+function renderReviews(reviews, container) {
+  container.innerHTML = '';
+  reviews.forEach(r => {
+    const card = document.createElement('div');
+    card.className = 'review-card';
+
+    const name = document.createElement('h3');
+    name.textContent = r.student_name;
+    card.appendChild(name);
+
+    const stars = document.createElement('div');
+    stars.className = 'stars';
+    const rating = Math.max(0, Math.min(5, r.rating));
+    stars.textContent = '★'.repeat(rating) + '☆'.repeat(5 - rating);
+    stars.setAttribute('aria-label', `Rating: ${rating} out of 5`);
+    card.appendChild(stars);
+
+    const text = document.createElement('p');
+    text.textContent = r.review_text;
+    card.appendChild(text);
+
+    container.appendChild(card);
+  });
+}
+
+fetchReviews();


### PR DESCRIPTION
## Summary
- fetch student reviews from published Google Sheet
- render testimonial cards on home page
- style testimonial cards and star ratings

## Testing
- `bundle exec jekyll build` *(fails: jekyll executable missing)*
- `bundle install` *(fails: 403 Forbidden fetching gems)*

------
https://chatgpt.com/codex/tasks/task_e_68c172c6ab7c8321b6720a735d73ae90