### PR TITLE
Render footer on home page

### DIFF
--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -93,6 +93,6 @@
   </section>
 
   <script type="module" src="{{ '/assets/js/reviews.js' | relative_url }}"></script>
-
+  {% include footer.html %}
   </body>
   </html>


### PR DESCRIPTION
## Summary
- include footer snippet in home layout so global footer renders on landing page

## Testing
- `bundle install` *(fails: Gem::Net::HTTPClientException 403 "Forbidden")*
- `bundle exec jekyll build` *(fails: bundler: command not found: jekyll)*
- `tail -n 30 /tmp/home_rendered.html`


------
https://chatgpt.com/codex/tasks/task_e_68c174e72eb88321bc1c92db8c61e63b