### PR TITLE
feat: highlight full Falowen suite

### DIFF
--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -18,7 +18,7 @@
   <header class="hero">
     <div class="wrap">
       <h1>Falowen Blog</h1>
-      <p>Your German conversation partner online, with tips for A1–C1, exam prep guidance, vocabulary strategies, and product updates from Learn Language Education Academy.</p>
+      <p>Course books, assignments, results and resources, exam mode, custom chat, vocab and Schreiben trainers—all in one place.</p>
       <a class="cta" href="https://falowen.app" target="_blank" rel="noopener">Try Falowen</a>
     </div>
   </header>


### PR DESCRIPTION
## Summary
- refocus home page hero on Falowen's full study suite
- keep call-to-action link to Falowen

## Testing
- `bundle exec jekyll build` *(fails: jekyll not installed)*
- `bundle install` *(fails: Gem::Net::HTTPClientException 403 "Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68c1759df2d0832187fbd7a51749d7ae