### PR TITLE
Link feature cards to new tool pages

### DIFF
--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -42,6 +42,20 @@
         <h3>Teacher + App</h3>
         <p>Assignments, feedback, and daily practice in one place.</p>
       </div>
+      <div class="feature">
+        <a href="/course-book/">
+          <img src="{{ '/assets/img/exam.svg' | relative_url }}" alt="Course book icon">
+          <h3>Course book</h3>
+          <p>Interactive course material to guide your study.</p>
+        </a>
+      </div>
+      <div class="feature">
+        <a href="/results/">
+          <img src="{{ '/assets/img/teacher.svg' | relative_url }}" alt="Results icon">
+          <h3>Results &amp; feedback</h3>
+          <p>Track your progress and review assignments.</p>
+        </a>
+      </div>
     </div>
   </section>
 

--- a/course-book.md
+++ b/course-book.md
@@ -1,0 +1,10 @@
+---
+layout: page
+title: Course Book
+permalink: /course-book/
+---
+
+# Course Book
+
+Falowen's Course Book gives you structured lessons that mirror classroom learning. Work through units, complete exercises and keep track of your progress directly in the app.
+

--- a/results.md
+++ b/results.md
@@ -1,0 +1,10 @@
+---
+layout: page
+title: Results
+permalink: /results/
+---
+
+# Results
+
+Check assignments and track how you are doing. The results page keeps your feedback and performance history in one convenient place.
+


### PR DESCRIPTION
## Summary
- Make course book and results feature cards clickable
- Add dedicated pages describing the Course Book and Results tools

## Testing
- `bundle install` *(fails: Gem::Net::HTTPClientException 403 Forbidden)*
- `bundle exec jekyll build` *(fails: bundler: command not found: jekyll)*

------
https://chatgpt.com/codex/tasks/task_e_68c176e8e40883219ddb65887ce34318