### PR TITLE
Refactor features section layout

### DIFF
--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -29,33 +29,39 @@
     <div class="features">
       <div class="feature">
         <img src="{{ '/assets/img/exam.svg' | relative_url }}" alt="Exam icon">
-        <h3>Exam-focused</h3>
-        <p>Practical guidance aligned to Goethe A1–C1 tasks.</p>
+        <div>
+          <h3>Exam-focused</h3>
+          <p>Practical guidance aligned to Goethe A1–C1 tasks.</p>
+        </div>
       </div>
       <div class="feature">
         <img src="{{ '/assets/img/vocab.svg' | relative_url }}" alt="Vocabulary icon">
-        <h3>Vocabulary that sticks</h3>
-        <p>Short examples and routines that build habits.</p>
+        <div>
+          <h3>Vocabulary that sticks</h3>
+          <p>Short examples and routines that build habits.</p>
+        </div>
       </div>
       <div class="feature">
         <img src="{{ '/assets/img/teacher.svg' | relative_url }}" alt="Teacher and app icon">
-        <h3>Teacher + App</h3>
-        <p>Assignments, feedback, and daily practice in one place.</p>
+        <div>
+          <h3>Teacher + App</h3>
+          <p>Assignments, feedback, and daily practice in one place.</p>
+        </div>
       </div>
-      <div class="feature">
-        <a href="/course-book/">
-          <img src="{{ '/assets/img/exam.svg' | relative_url }}" alt="Course book icon">
+      <a class="feature" href="/course-book/">
+        <img src="{{ '/assets/img/exam.svg' | relative_url }}" alt="Course book icon">
+        <div>
           <h3>Course book</h3>
           <p>Interactive course material to guide your study.</p>
-        </a>
-      </div>
-      <div class="feature">
-        <a href="/results/">
-          <img src="{{ '/assets/img/teacher.svg' | relative_url }}" alt="Results icon">
+        </div>
+      </a>
+      <a class="feature" href="/results/">
+        <img src="{{ '/assets/img/teacher.svg' | relative_url }}" alt="Results icon">
+        <div>
           <h3>Results &amp; feedback</h3>
           <p>Track your progress and review assignments.</p>
-        </a>
-      </div>
+        </div>
+      </a>
     </div>
   </section>
 

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -18,11 +18,11 @@ h1{font-weight:900;line-height:1.1}
 .hero p{margin:0 0 16px 0;color:var(--muted);font-size:clamp(16px,2vw,18px)}
 .cta{display:inline-block;background:var(--brand);color:#fff;text-decoration:none;padding:12px 16px;border-radius:12px;font-weight:800;border:1px solid rgba(37,49,126,.9);box-shadow:0 10px 22px var(--ring)}
 .cta:hover{filter:brightness(1.05)}
-.features{display:grid;grid-template-columns:repeat(auto-fit,minmax(220px,1fr));gap:12px;margin:18px 0 8px}
-.feature{background:var(--card);border:1px solid var(--line);border-radius:14px;padding:14px 16px;box-shadow:0 6px 14px rgba(2,6,23,.06)}
-.feature h3{margin:0 0 6px 0;font-size:18px;color:var(--ink)}
+.features{display:flex;flex-wrap:wrap;justify-content:center;gap:12px;margin:18px 0 8px}
+.feature{display:flex;align-items:flex-start;gap:8px;background:var(--card);border:1px solid var(--line);border-radius:14px;padding:10px 12px;box-shadow:0 6px 14px rgba(2,6,23,.06);color:inherit;text-decoration:none}
+.feature h3{margin:0 0 4px 0;font-size:18px;color:var(--ink)}
 .feature p{margin:0;color:var(--muted);font-size:15px}
-.feature img{width:32px;margin-bottom:8px}
+.feature img{width:32px;margin-right:8px}
 .section{padding:10px 0 28px}
 .section h2{margin:8px 0 10px 0;color:var(--ink);font-size:24px}
 .grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(260px,1fr));gap:14px;align-items:stretch}

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -94,22 +94,28 @@ h1 {
 }
 
 .features {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
   gap: $spacing-unit * 1.5;
   margin: $spacing-unit * 2.25 0 $spacing-unit;
 }
 
 .feature {
+  display: flex;
+  align-items: flex-start;
+  gap: $spacing-unit;
   background: var(--card);
   border: 1px solid var(--line);
   border-radius: 14px;
-  padding: 14px 16px;
+  padding: $spacing-unit * 1.25 $spacing-unit * 1.5;
   box-shadow: 0 6px 14px rgba(2,6,23,.06);
+  color: inherit;
+  text-decoration: none;
 }
 
 .feature h3 {
-  margin: 0 0 6px 0;
+  margin: 0 0 4px 0;
   font-size: 18px;
   color: var(--ink);
 }
@@ -122,7 +128,7 @@ h1 {
 
 .feature img {
   width: 32px;
-  margin-bottom: $spacing-unit;
+  margin-right: $spacing-unit;
 }
 
 .section {


### PR DESCRIPTION
## Summary
- replace highlight grid with centered flex row and inline icon cards
- restructure home feature markup so icons sit beside text and linked cards are anchors

## Testing
- `bundle exec jekyll build` *(fails: bundler: command not found: jekyll)*
- `bundle install` *(fails: Gem::Net::HTTPClientException 403 "Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68c17950a5e48321826aaf1e6b8559fc