### PR TITLE
Show top three posts on home without pagination

### DIFF
--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -77,8 +77,8 @@
   <!-- Latest posts grid -->
   <section class="wrap section">
     <h2>Latest articles</h2>
-    <div class="grid">
-      {% for post in paginator.posts %}
+    <div class="latest">
+      {% for post in site.posts | slice: 0, 3 %}
       <article class="card">
         <a href="{{ post.url | relative_url }}">
           {% if post.image %}
@@ -102,14 +102,6 @@
       </article>
       {% endfor %}
     </div>
-    <nav class="pagination">
-      {% if paginator.previous_page %}
-        <a class="newer" href="{{ paginator.previous_page_path | relative_url }}">&laquo; Newer Posts</a>
-      {% endif %}
-      {% if paginator.next_page %}
-        <a class="older" href="{{ paginator.next_page_path | relative_url }}">Older Posts &raquo;</a>
-      {% endif %}
-    </nav>
   </section>
 
   <script type="module" src="{{ '/assets/js/reviews.js' | relative_url }}"></script>

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -25,8 +25,8 @@ h1{font-weight:900;line-height:1.1}
 .feature img{width:32px;margin-right:8px}
 .section{padding:10px 0 28px}
 .section h2{margin:8px 0 10px 0;color:var(--ink);font-size:24px}
-.grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(260px,1fr));gap:14px;align-items:stretch}
-.card{background:var(--card);border:1px solid var(--line);border-radius:14px;padding:14px 16px;box-shadow:0 6px 14px rgba(2,6,23,.06);display:flex;flex-direction:column;gap:8px}
+.latest{display:flex;gap:14px}
+.card{background:var(--card);border:1px solid var(--line);border-radius:14px;padding:14px 16px;box-shadow:0 6px 14px rgba(2,6,23,.06);display:flex;flex-direction:column;gap:8px;flex:1}
 .card a{color:inherit;text-decoration:none}
 .card h3{margin:0;color:var(--ink);font-size:18px}
 .card p{margin:0;color:var(--muted);font-size:15px}

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -141,11 +141,9 @@ h1 {
   font-size: 24px;
 }
 
-.grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+.latest {
+  display: flex;
   gap: 14px;
-  align-items: stretch;
 }
 
 .card {
@@ -157,6 +155,7 @@ h1 {
   display: flex;
   flex-direction: column;
   gap: $spacing-unit;
+  flex: 1;
 }
 
 .card a {


### PR DESCRIPTION
## Summary
- Display only the latest three posts on the home page
- Replace grid with flex-based `.latest` layout and make cards expand
- Remove pagination controls for latest articles section

## Testing
- `bundle exec jekyll build` *(fails: command not found: jekyll)*
- `bundle install` *(fails: Gem::Net::HTTPClientException 403 "Forbidden")*


------
https://chatgpt.com/codex/tasks/task_e_68c17f8afa808321b9f648fa01a2723d