### PR TITLE
Use Poppins for headings and hierarchy

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -1,4 +1,4 @@
-@import url("https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700;900&display=swap");
+@import url("https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700;900&family=Poppins:wght@400;500;600;700&display=swap");
 :root{
   --brand:#25317e;
   --bg:#f3f7fb;
@@ -10,11 +10,16 @@
 }
 html,body{margin:0;padding:0;background:var(--bg);color:var(--ink);font-family:Inter,system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif;font-weight:400;line-height:1.6}
 img{max-width:100%;height:auto}
-h1,h2,h3,h4,h5,h6{font-family:Inter,system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif;font-weight:700;line-height:1.3}
-h1{font-weight:900;line-height:1.1}
+h1,h2,h3,h4,h5,h6{font-family:Poppins,Inter,system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif;line-height:1.3}
+h1{font-size:2.25rem;font-weight:700;line-height:1.1}
+h2{font-size:1.75rem;font-weight:600}
+h3{font-size:1.5rem;font-weight:600}
+h4{font-size:1.25rem;font-weight:500}
+h5{font-size:1rem;font-weight:500}
+h6{font-size:.875rem;font-weight:500}
 .wrap{max-width:1100px;margin:0 auto;padding:0 18px}
 .hero{background:linear-gradient(180deg,var(--bg),rgba(243,247,251,0));border-top:6px solid var(--brand);padding:44px 0 22px}
-.hero h1{margin:0 0 10px 0;font-size:clamp(28px,4vw,44px);line-height:1.1;color:var(--ink);font-weight:900}
+.hero h1{margin:0 0 10px 0;font-size:clamp(28px,4vw,44px);line-height:1.1;color:var(--ink);font-weight:700}
 .hero p{margin:0 0 16px 0;color:var(--muted);font-size:clamp(16px,2vw,18px)}
 .cta{display:inline-block;background:var(--brand);color:#fff;text-decoration:none;padding:12px 16px;border-radius:12px;font-weight:800;border:1px solid rgba(37,49,126,.9);box-shadow:0 10px 22px var(--ring)}
 .cta:hover{filter:brightness(1.05)}

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -1,7 +1,7 @@
 ---
 ---
 
-@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700;900&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700;900&family=Poppins:wght@400;500;600;700&display=swap');
 
 $color-brand: #25317e;
 $color-background: #f3f7fb;
@@ -13,6 +13,7 @@ $color-line: rgba(148,163,184,0.35);
 
 $spacing-unit: 8px;
 $font-family-base: 'Inter', system-ui, -apple-system, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+$font-family-heading: 'Poppins', $font-family-base;
 
 :root {
   --brand: #{$color-brand};
@@ -41,14 +42,39 @@ img {
 }
 
 h1, h2, h3, h4, h5, h6 {
-  font-family: $font-family-base;
-  font-weight: 700;
+  font-family: $font-family-heading;
   line-height: 1.3;
 }
 
 h1 {
-  font-weight: 900;
+  font-size: 2.25rem;
+  font-weight: 700;
   line-height: 1.1;
+}
+
+h2 {
+  font-size: 1.75rem;
+  font-weight: 600;
+}
+
+h3 {
+  font-size: 1.5rem;
+  font-weight: 600;
+}
+
+h4 {
+  font-size: 1.25rem;
+  font-weight: 500;
+}
+
+h5 {
+  font-size: 1rem;
+  font-weight: 500;
+}
+
+h6 {
+  font-size: 0.875rem;
+  font-weight: 500;
 }
 
 .wrap {
@@ -68,7 +94,7 @@ h1 {
   font-size: clamp(28px, 4vw, 44px);
   line-height: 1.1;
   color: var(--ink);
-  font-weight: 900;
+  font-weight: 700;
 }
 
 .hero p {


### PR DESCRIPTION
## Summary
- import Poppins display font and define `$font-family-heading`
- apply new heading font across h1–h6 with explicit sizes and weights
- update compiled CSS to match new styles

## Testing
- `npx -p sass sass assets/css/main.scss assets/css/main.css` *(fails: 403 Forbidden to fetch sass package)*
- `bundle exec jekyll build` *(fails: bundler cannot find jekyll executable)*

------
https://chatgpt.com/codex/tasks/task_e_68c19b3690d08321be1ff3cbfcd2cd88