### PR TITLE
Refactor top navigation with list semantics and active styling

### DIFF
--- a/_includes/topnav.html
+++ b/_includes/topnav.html
@@ -1,11 +1,27 @@
 <div class="wrap">
   <nav class="topnav">
-    <a href="{{ '/' | relative_url }}">Home</a>
-    <a href="{{ '/about/' | relative_url }}">About</a>
-    <a href="{{ '/search/' | relative_url }}">Search</a>
-    <a href="{{ '/categories/' | relative_url }}">Categories</a>
-    <a href="{{ '/tags/' | relative_url }}">Tags</a>
-    <a href="{{ '/blogs/' | relative_url }}">Blogs</a>
-    <a href="https://register.falowen.app" target="_blank" rel="noopener">Register</a>
+    <ul class="topnav-list">
+      <li class="{% if page.url == '/' %}active{% endif %}">
+        <a href="{{ '/' | relative_url }}">Home</a>
+      </li>
+      <li class="{% if page.url == '/about/' %}active{% endif %}">
+        <a href="{{ '/about/' | relative_url }}">About</a>
+      </li>
+      <li class="{% if page.url == '/search/' %}active{% endif %}">
+        <a href="{{ '/search/' | relative_url }}">Search</a>
+      </li>
+      <li class="{% if page.url == '/categories/' %}active{% endif %}">
+        <a href="{{ '/categories/' | relative_url }}">Categories</a>
+      </li>
+      <li class="{% if page.url == '/tags/' %}active{% endif %}">
+        <a href="{{ '/tags/' | relative_url }}">Tags</a>
+      </li>
+      <li class="{% if page.url == '/blogs/' %}active{% endif %}">
+        <a href="{{ '/blogs/' | relative_url }}">Blogs</a>
+      </li>
+      <li>
+        <a href="https://register.falowen.app" target="_blank" rel="noopener">Register</a>
+      </li>
+    </ul>
   </nav>
 </div>

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -38,9 +38,12 @@ h6{font-size:.875rem;font-weight:500}
 .meta{font-size:13px;color:var(--muted)}
 .actions{display:flex;gap:10px;flex-wrap:wrap;margin-top:8px}
 .pill{display:inline-block;border:1px solid var(--line);padding:6px 10px;border-radius:999px;font-size:13px;color:var(--ink);text-decoration:none;background:var(--card)}
-.topnav{display:flex;gap:14px;align-items:center;justify-content:flex-end;padding:10px 0}
-.topnav a{color:var(--brand);text-decoration:none;font-weight:700}
-.topnav a:hover{text-decoration:underline}
+.topnav{padding:10px 0}
+.topnav-list{display:flex;gap:14px;align-items:center;justify-content:flex-end;list-style:none;margin:0;padding:0}
+.topnav-list li{margin:0}
+.topnav-list a{color:var(--brand);text-decoration:none;font-weight:700;padding:6px 8px;border-radius:6px;transition:background .2s,color .2s}
+.topnav-list a:hover,.topnav-list a:focus-visible{background:var(--brand);color:#fff}
+.topnav-list li.active a{background:var(--brand);color:#fff}
 .post-nav{display:flex;justify-content:space-between;margin:16px 0}
 .post-nav a{color:var(--brand);text-decoration:none;font-weight:700}
 .post-nav a:hover{text-decoration:underline}

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -233,21 +233,41 @@ h6 {
 }
 
 .topnav {
+  padding: 10px 0;
+}
+
+.topnav-list {
   display: flex;
   gap: 14px;
   align-items: center;
   justify-content: flex-end;
-  padding: 10px 0;
+  list-style: none;
+  margin: 0;
+  padding: 0;
 }
 
-.topnav a {
+.topnav-list li {
+  margin: 0;
+}
+
+.topnav-list a {
   color: var(--brand);
   text-decoration: none;
   font-weight: 700;
+  padding: 6px 8px;
+  border-radius: 6px;
+  transition: background 0.2s, color 0.2s;
 }
 
-.topnav a:hover {
-  text-decoration: underline;
+.topnav-list a:hover,
+.topnav-list a:focus-visible {
+  background: var(--brand);
+  color: #fff;
+}
+
+.topnav-list li.active a {
+  background: var(--brand);
+  color: #fff;
 }
 
 .post-nav {


### PR DESCRIPTION
## Summary
- wrap top navigation links in a semantic `<ul class="topnav-list">` structure with active state support
- style `.topnav-list` items with spacing, hover/focus transitions, and active highlighting
- include compiled CSS reflecting new top navigation styles

## Testing
- `bundle install` *(fails: Gem::Net::HTTPClientException 403 "Forbidden")*
- `npx sass assets/css/main.scss` *(fails: npm error 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c19cc61d688321a75260503cbcc04b