### PR TITLE
feat: enhance CTA with gradient and icon

### DIFF
--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -19,7 +19,7 @@
     <div class="wrap">
       <h1>Falowen Blog</h1>
       <p>Course books, assignments, results and resources, exam mode, custom chat, vocab and Schreiben trainers—all in one place.</p>
-      <a class="cta" href="https://falowen.app" target="_blank" rel="noopener">Try Falowen</a>
+      <a class="cta" href="https://falowen.app" target="_blank" rel="noopener">Try Falowen <span class="cta-icon">→</span></a>
     </div>
   </header>
 

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -21,8 +21,9 @@ h6{font-size:.875rem;font-weight:500}
 .hero{background:linear-gradient(180deg,var(--bg),rgba(243,247,251,0));border-top:6px solid var(--brand);padding:44px 0 22px}
 .hero h1{margin:0 0 10px 0;font-size:clamp(28px,4vw,44px);line-height:1.1;color:var(--ink);font-weight:700}
 .hero p{margin:0 0 16px 0;color:var(--muted);font-size:clamp(16px,2vw,18px)}
-.cta{display:inline-block;background:var(--brand);color:#fff;text-decoration:none;padding:12px 16px;border-radius:12px;font-weight:800;border:1px solid rgba(37,49,126,.9);box-shadow:0 10px 22px var(--ring)}
-.cta:hover{filter:brightness(1.05)}
+.cta{display:inline-flex;align-items:center;background:linear-gradient(135deg,#3140a5,#25317e);color:#fff;text-decoration:none;padding:12px 16px;border-radius:12px;font-weight:800;border:1px solid rgba(37,49,126,.9);box-shadow:0 4px 14px rgba(37,49,126,.25);transition:background .3s ease,box-shadow .3s ease}
+.cta:hover{background:linear-gradient(135deg,#3648b9,#25317e);box-shadow:0 6px 18px rgba(37,49,126,.35)}
+.cta-icon{margin-left:8px;display:inline-block;line-height:1;font-size:1.25em}
 .features{display:flex;flex-wrap:wrap;justify-content:center;gap:12px;margin:18px 0 8px}
 .feature{display:flex;align-items:flex-start;gap:8px;background:var(--card);border:1px solid var(--line);border-radius:14px;padding:10px 12px;box-shadow:0 6px 14px rgba(2,6,23,.06);color:inherit;text-decoration:none}
 .feature h3{margin:0 0 4px 0;font-size:18px;color:var(--ink)}

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -104,19 +104,29 @@ h6 {
 }
 
 .cta {
-  display: inline-block;
-  background: var(--brand);
+  display: inline-flex;
+  align-items: center;
+  background: linear-gradient(135deg, lighten($color-brand, 10%), $color-brand);
   color: #fff;
   text-decoration: none;
   padding: 12px 16px;
   border-radius: 12px;
   font-weight: 800;
-  border: 1px solid rgba(37,49,126,.9);
-  box-shadow: 0 10px 22px var(--ring);
+  border: 1px solid rgba(37,49,126, .9);
+  box-shadow: 0 4px 14px rgba(37,49,126, 0.25);
+  transition: background 0.3s ease, box-shadow 0.3s ease;
 }
 
 .cta:hover {
-  filter: brightness(1.05);
+  background: linear-gradient(135deg, lighten($color-brand, 15%), $color-brand);
+  box-shadow: 0 6px 18px rgba(37,49,126, 0.35);
+}
+
+.cta-icon {
+  margin-left: $spacing-unit;
+  display: inline-block;
+  line-height: 1;
+  font-size: 1.25em;
 }
 
 .features {


### PR DESCRIPTION
## Summary
- refine main call-to-action button with brand gradient, hover transition, and drop shadow
- insert arrow icon into CTA link on home page and style for alignment

## Testing
- `npx sass --no-source-map --style=compressed assets/css/main.scss assets/css/main.css` *(fails: 403 Forbidden from registry.npmjs.org)*
- `bundle install` *(fails: Gem::Net::HTTPClientException 403 "Forbidden")*


------
https://chatgpt.com/codex/tasks/task_e_68c19f549d9883219e405bc1d66f6c56