### PR TITLE
Refactor top navigation with logo and flex styling

### DIFF
--- a/_includes/topnav.html
+++ b/_includes/topnav.html
@@ -1,5 +1,8 @@
-<div class="wrap">
-  <nav class="topnav">
+<div class="wrap topnav-container">
+  <div class="topnav-logo">
+    <a href="{{ '/' | relative_url }}">{{ site.title }}</a>
+  </div>
+  <nav class="topnav" aria-label="Main navigation">
     <ul class="topnav-list">
       <li class="{% if page.url == '/' %}active{% endif %}">
         <a href="{{ '/' | relative_url }}">Home</a>

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -39,12 +39,15 @@ h6{font-size:.875rem;font-weight:500}
 .meta{font-size:13px;color:var(--muted)}
 .actions{display:flex;gap:10px;flex-wrap:wrap;margin-top:8px}
 .pill{display:inline-block;border:1px solid var(--line);padding:6px 10px;border-radius:999px;font-size:13px;color:var(--ink);text-decoration:none;background:var(--card)}
-.topnav{padding:10px 0}
-.topnav-list{display:flex;gap:14px;align-items:center;justify-content:flex-end;list-style:none;margin:0;padding:0}
+.site-header{background:var(--card);border-bottom:1px solid var(--line);box-shadow:0 2px 4px rgba(2,6,23,.06)}
+.topnav-container{display:flex;align-items:center;justify-content:space-between;padding:10px 0}
+.topnav-logo a{color:var(--brand);text-decoration:none;font-weight:700;font-size:1.25rem;transition:color .2s}
+.topnav-logo a:hover,.topnav-logo a:focus-visible{color:#192257}
+.topnav-list{display:flex;flex-direction:row;align-items:center;gap:14px;list-style:none;margin:0;padding:0}
 .topnav-list li{margin:0}
 .topnav-list a{color:var(--brand);text-decoration:none;font-weight:700;padding:6px 8px;border-radius:6px;transition:background .2s,color .2s}
-.topnav-list a:hover,.topnav-list a:focus-visible{background:var(--brand);color:#fff}
-.topnav-list li.active a{background:var(--brand);color:#fff}
+.topnav-list a:hover,.topnav-list a:focus-visible{background:#3140a5;color:#fff}
+.topnav-list li.active a{background:#25317e;color:#fff}
 .post-nav{display:flex;justify-content:space-between;margin:16px 0}
 .post-nav a{color:var(--brand);text-decoration:none;font-weight:700}
 .post-nav a:hover{text-decoration:underline}

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -242,15 +242,37 @@ h6 {
   background: #fff;
 }
 
-.topnav {
+.site-header {
+  background: var(--card);
+  border-bottom: 1px solid var(--line);
+  box-shadow: 0 2px 4px rgba(2,6,23,.06);
+}
+
+.topnav-container {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
   padding: 10px 0;
+}
+
+.topnav-logo a {
+  color: var(--brand);
+  text-decoration: none;
+  font-weight: 700;
+  font-size: 1.25rem;
+  transition: color 0.2s;
+}
+
+.topnav-logo a:hover,
+.topnav-logo a:focus-visible {
+  color: darken($color-brand, 10%);
 }
 
 .topnav-list {
   display: flex;
-  gap: 14px;
+  flex-direction: row;
   align-items: center;
-  justify-content: flex-end;
+  gap: 14px;
   list-style: none;
   margin: 0;
   padding: 0;
@@ -271,12 +293,12 @@ h6 {
 
 .topnav-list a:hover,
 .topnav-list a:focus-visible {
-  background: var(--brand);
+  background: lighten($color-brand, 10%);
   color: #fff;
 }
 
 .topnav-list li.active a {
-  background: var(--brand);
+  background: $color-brand;
   color: #fff;
 }
 


### PR DESCRIPTION
## Summary
- Add logo/title and `aria-label` to top navigation with flexbox layout
- Style navigation bar with brand-consistent hover/active states and subtle separation
- Update compiled CSS for new navigation styles

## Testing
- `npx sass assets/css/main.scss assets/css/main.css` *(fails: 403 Forbidden - GET https://registry.npmjs.org/sass)*

------
https://chatgpt.com/codex/tasks/task_e_68c1a105d3a48321981ed31f0d5ee71f