### PR TITLE
feat: add dark theme and responsive navigation

### DIFF
--- a/_includes/topnav.html
+++ b/_includes/topnav.html
@@ -2,6 +2,7 @@
   <div class="topnav-logo">
     <a href="{{ '/' | relative_url }}">{{ site.title }}</a>
   </div>
+  <button class="topnav-toggle" aria-expanded="false" aria-label="Menu">&#9776;</button>
   <nav class="topnav" aria-label="Main navigation">
     <ul class="topnav-list">
       <li class="{% if page.url == '/' %}active{% endif %}">
@@ -25,6 +26,22 @@
       <li>
         <a href="https://register.falowen.app" target="_blank" rel="noopener">Register</a>
       </li>
+      <li>
+        <button id="theme-toggle" type="button">Dark Mode</button>
+      </li>
     </ul>
   </nav>
 </div>
+<script>
+  document.addEventListener('DOMContentLoaded', function() {
+    var toggle = document.querySelector('.topnav-toggle');
+    var list = document.querySelector('.topnav-list');
+    if (toggle && list) {
+      toggle.addEventListener('click', function() {
+        var expanded = toggle.getAttribute('aria-expanded') === 'true';
+        toggle.setAttribute('aria-expanded', (!expanded).toString());
+        list.classList.toggle('open');
+      });
+    }
+  });
+</script>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,7 +1,7 @@
 ---
 ---
 <!DOCTYPE html>
-<html lang="{{ page.lang | default: site.lang | default: 'en' }}">
+<html lang="{{ page.lang | default: site.lang | default: 'en' }}" data-theme="light">
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1" />
@@ -9,7 +9,7 @@
     {% include head-custom.html %}
     <link rel="stylesheet" href="{{ '/assets/css/main.css' | relative_url }}">
   </head>
-  <body class="light">
+  <body>
     {% include header.html %}
     <main class="page-content">
       <div class="wrap">
@@ -17,5 +17,6 @@
       </div>
     </main>
     {% include footer.html %}
+    <script src="{{ '/assets/js/theme-toggle.js' | relative_url }}"></script>
   </body>
 </html>

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -3,11 +3,12 @@
   --brand:#25317e;
   --bg:#f3f7fb;
   --ink:#1c2440;
-  --muted:#64748b;
+  --muted:#334155;
   --card:#ffffff;
   --ring:rgba(37,49,126,.18);
   --line:rgba(148,163,184,.35);
 }
+[data-theme=dark]{--brand:#25317e;--bg:#1c2440;--ink:#f3f7fb;--muted:#cbd5e1;--card:#334155;--ring:rgba(37,49,126,.5);--line:rgba(148,163,184,.2)}
 html,body{margin:0;padding:0;background:var(--bg);color:var(--ink);font-family:Inter,system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif;font-weight:400;line-height:1.6}
 img{max-width:100%;height:auto}
 h1,h2,h3,h4,h5,h6{font-family:Poppins,Inter,system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif;line-height:1.3}
@@ -40,14 +41,16 @@ h6{font-size:.875rem;font-weight:500}
 .actions{display:flex;gap:10px;flex-wrap:wrap;margin-top:8px}
 .pill{display:inline-block;border:1px solid var(--line);padding:6px 10px;border-radius:999px;font-size:13px;color:var(--ink);text-decoration:none;background:var(--card)}
 .site-header{background:var(--card);border-bottom:1px solid var(--line);box-shadow:0 2px 4px rgba(2,6,23,.06)}
-.topnav-container{display:flex;align-items:center;justify-content:space-between;padding:10px 0}
+.topnav-container{display:flex;align-items:center;justify-content:space-between;padding:10px 0;position:relative}
 .topnav-logo a{color:var(--brand);text-decoration:none;font-weight:700;font-size:1.25rem;transition:color .2s}
 .topnav-logo a:hover,.topnav-logo a:focus-visible{color:#192257}
+.topnav-toggle{display:none;background:none;border:none;font-size:1.5rem;color:var(--brand);cursor:pointer}
 .topnav-list{display:flex;flex-direction:row;align-items:center;gap:14px;list-style:none;margin:0;padding:0}
 .topnav-list li{margin:0}
-.topnav-list a{color:var(--brand);text-decoration:none;font-weight:700;padding:6px 8px;border-radius:6px;transition:background .2s,color .2s}
-.topnav-list a:hover,.topnav-list a:focus-visible{background:#3140a5;color:#fff}
+.topnav-list a,.topnav-list button{color:var(--brand);text-decoration:none;font-weight:700;padding:6px 8px;border-radius:6px;transition:background .2s,color .2s;background:none;border:none;cursor:pointer}
+.topnav-list a:hover,.topnav-list a:focus-visible,.topnav-list button:hover,.topnav-list button:focus-visible{background:#3140a5;color:#fff}
 .topnav-list li.active a{background:#25317e;color:#fff}
+@media (max-width:640px){.topnav-toggle{display:block}.topnav-list{display:none;flex-direction:column;position:absolute;top:100%;right:0;background:var(--card);border:1px solid var(--line);padding:8px 0;border-radius:8px;z-index:10}.topnav-list.open{display:flex}}
 .post-nav{display:flex;justify-content:space-between;margin:16px 0}
 .post-nav a{color:var(--brand);text-decoration:none;font-weight:700}
 .post-nav a:hover{text-decoration:underline}

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -11,6 +11,14 @@ $color-card: #ffffff;
 $color-ring: rgba(37,49,126,0.18);
 $color-line: rgba(148,163,184,0.35);
 
+// Dark theme palette
+$color-background-dark: #1c2440;
+$color-ink-dark: #f3f7fb;
+$color-muted-dark: #cbd5e1;
+$color-card-dark: #334155;
+$color-ring-dark: rgba(37,49,126,0.5);
+$color-line-dark: rgba(148,163,184,0.2);
+
 $spacing-unit: 8px;
 $font-family-base: 'Inter', system-ui, -apple-system, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
 $font-family-heading: 'Poppins', $font-family-base;
@@ -23,6 +31,16 @@ $font-family-heading: 'Poppins', $font-family-base;
   --card: #{$color-card};
   --ring: #{$color-ring};
   --line: #{$color-line};
+}
+
+[data-theme='dark'] {
+  --brand: #{$color-brand};
+  --bg: #{$color-background-dark};
+  --ink: #{$color-ink-dark};
+  --muted: #{$color-muted-dark};
+  --card: #{$color-card-dark};
+  --ring: #{$color-ring-dark};
+  --line: #{$color-line-dark};
 }
 
 html,
@@ -253,6 +271,7 @@ h6 {
   align-items: center;
   justify-content: space-between;
   padding: 10px 0;
+  position: relative;
 }
 
 .topnav-logo a {
@@ -266,6 +285,15 @@ h6 {
 .topnav-logo a:hover,
 .topnav-logo a:focus-visible {
   color: darken($color-brand, 10%);
+}
+
+.topnav-toggle {
+  display: none;
+  background: none;
+  border: none;
+  font-size: 1.5rem;
+  color: var(--brand);
+  cursor: pointer;
 }
 
 .topnav-list {
@@ -282,17 +310,23 @@ h6 {
   margin: 0;
 }
 
-.topnav-list a {
+.topnav-list a,
+.topnav-list button {
   color: var(--brand);
   text-decoration: none;
   font-weight: 700;
   padding: 6px 8px;
   border-radius: 6px;
   transition: background 0.2s, color 0.2s;
+  background: none;
+  border: none;
+  cursor: pointer;
 }
 
 .topnav-list a:hover,
-.topnav-list a:focus-visible {
+.topnav-list a:focus-visible,
+.topnav-list button:hover,
+.topnav-list button:focus-visible {
   background: lighten($color-brand, 10%);
   color: #fff;
 }
@@ -300,6 +334,29 @@ h6 {
 .topnav-list li.active a {
   background: $color-brand;
   color: #fff;
+}
+
+@media (max-width: 640px) {
+  .topnav-toggle {
+    display: block;
+  }
+
+  .topnav-list {
+    display: none;
+    flex-direction: column;
+    position: absolute;
+    top: 100%;
+    right: 0;
+    background: var(--card);
+    border: 1px solid var(--line);
+    padding: 8px 0;
+    border-radius: 8px;
+    z-index: 10;
+  }
+
+  .topnav-list.open {
+    display: flex;
+  }
 }
 
 .post-nav {

--- a/assets/js/theme-toggle.js
+++ b/assets/js/theme-toggle.js
@@ -1,0 +1,25 @@
+(function() {
+  const storageKey = 'theme';
+  const toggle = document.getElementById('theme-toggle');
+
+  function apply(theme) {
+    document.documentElement.setAttribute('data-theme', theme);
+    if (toggle) {
+      toggle.textContent = theme === 'dark' ? 'Light Mode' : 'Dark Mode';
+    }
+  }
+
+  let current = localStorage.getItem(storageKey);
+  if (!current) {
+    current = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+  }
+  apply(current);
+
+  if (toggle) {
+    toggle.addEventListener('click', function() {
+      current = current === 'dark' ? 'light' : 'dark';
+      localStorage.setItem(storageKey, current);
+      apply(current);
+    });
+  }
+})();


### PR DESCRIPTION
## Summary
- add dark theme variables and CSS switches
- provide theme toggle script and include it globally
- collapse top navigation into hamburger menu on small screens

## Testing
- `bundle exec jekyll build` *(fails: bundler: command not found: jekyll)*
- `bundle install` *(fails: Gem::Net::HTTPClientException 403 "Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68c1a269740883219da595a454ac3e6e