### PR TITLE
fix: style search placeholder

### DIFF
--- a/search.md
+++ b/search.md
@@ -4,7 +4,7 @@ title: Search
 permalink: /search/
 ---
 
-<input type="text" id="search-input" placeholder="Search posts..." style="width:100%;padding:10px;border-radius:10px;border:1px solid #cbd5e1;">
+<input type="text" id="search-input" placeholder="Search posts...">
 <ul id="results-container" class="search-results"></ul>
 
 <script src="https://cdn.jsdelivr.net/npm/simple-jekyll-search@1.11.1/dest/simple-jekyll-search.min.js"></script>
@@ -21,8 +21,10 @@ permalink: /search/
 </script>
 
 <style>
+#search-input{width:100%;padding:10px;border-radius:10px;border:1px solid #cbd5e1}
+#search-input::placeholder{color:var(--muted);opacity:1}
 .search-results{list-style:none;padding-left:0;margin-top:12px}
 .search-results li{padding:8px 0;border-bottom:1px solid #e2e8f0}
 .search-results a{font-weight:700}
-  .search-results span{color:#334155;margin-left:6px}
-  </style>
+.search-results span{color:#334155;margin-left:6px}
+</style>


### PR DESCRIPTION
## Summary
- style search input with CSS and proper placeholder color

## Testing
- `bundle exec jekyll build` *(fails: command not found)*
- `bundle install` *(fails: Gem::Net::HTTPClientException 403 "Forbidden")*


------
https://chatgpt.com/codex/tasks/task_e_68c1a7811c18832193f5a033d0dc45ad