### PR TITLE
Wrap Giscus comments in conditional

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -28,23 +28,25 @@ layout: default
     {% endif %}
   </nav>
 
-  <section id="comments">
-    <div id="giscus_thread"></div>
-    <script src="https://giscus.app/client.js"
-            data-repo="{{ site.giscus.repo }}"
-            data-repo-id="{{ site.giscus.repo_id }}"
-            data-category="{{ site.giscus.category }}"
-            data-category-id="{{ site.giscus.category_id }}"
-            data-mapping="pathname"
-            data-reactions-enabled="1"
-            data-emit-metadata="0"
-            data-input-position="bottom"
-            data-theme="{{ site.giscus.theme | default: 'light' }}"
-            data-lang="{{ site.giscus.lang | default: 'en' }}"
-            crossorigin="anonymous"
-            async>
-    </script>
-    <noscript>Please enable JavaScript to view the comments powered by Giscus.</noscript>
-  </section>
+  {% if site.giscus and site.giscus.repo %}
+    <section id="comments">
+      <div id="giscus_thread"></div>
+      <script src="https://giscus.app/client.js"
+              data-repo="{{ site.giscus.repo }}"
+              data-repo-id="{{ site.giscus.repo_id }}"
+              data-category="{{ site.giscus.category }}"
+              data-category-id="{{ site.giscus.category_id }}"
+              data-mapping="pathname"
+              data-reactions-enabled="1"
+              data-emit-metadata="0"
+              data-input-position="bottom"
+              data-theme="{{ site.giscus.theme | default: 'light' }}"
+              data-lang="{{ site.giscus.lang | default: 'en' }}"
+              crossorigin="anonymous"
+              async>
+      </script>
+      <noscript>Please enable JavaScript to view the comments powered by Giscus.</noscript>
+    </section>
+  {% endif %}
   {% include related-posts.html %}
 </article>


### PR DESCRIPTION
## Summary
- Wrap Giscus comment section in a conditional so comments render only when `site.giscus.repo` is configured

## Testing
- `bundle install` *(fails: Gem::Net::HTTPClientException 403 "Forbidden")*
- `bundle exec jekyll build` *(fails: bundler: command not found: jekyll)*

------
https://chatgpt.com/codex/tasks/task_e_68c1a8b4a0cc832189f260c9bf892a9b