### PR TITLE
feat: add lazy loading and dimensions to post card images

### DIFF
--- a/_includes/post-card.html
+++ b/_includes/post-card.html
@@ -2,7 +2,12 @@
 <article class="post-card">
   <a class="post-card-link" href="{{ p.url | relative_url }}">
     {% if p.image %}
-    <img class="post-card-img" src="{{ p.image }}" alt="{{ p.title }}" />
+    <img class="post-card-img"
+         src="{{ p.image }}"
+         alt="{{ p.title }}"
+         loading="lazy"
+         width="{{ p.image_width | default: 600 }}"
+         height="{{ p.image_height | default: 400 }}" />
     {% endif %}
     <h3 class="post-card-title">{{ p.title }}</h3>
     {% if p.excerpt %}


### PR DESCRIPTION
## Summary
- lazy load post card images
- add optional image dimensions from front matter with fallback sizes

## Testing
- `bundle exec jekyll build` *(fails: bundler: command not found: jekyll)*
- `bundle install` *(fails: Gem::Net::HTTPClientException 403 "Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68c1bddfeea48321baf30be648281820