### PR TITLE
refactor: move post card styles to stylesheet

### DIFF
--- a/_includes/post-card.html
+++ b/_includes/post-card.html
@@ -21,14 +21,3 @@
     </div>
   </a>
 </article>
-
-  <style>
-  .post-card{background:var(--card);border:1px solid var(--line);border-radius:14px;padding:14px 16px;
-             box-shadow:0 6px 14px rgba(2,6,23,.06);transition:transform .08s ease}
-  .post-card:hover{transform:translateY(-2px)}
-  .post-card-title{margin:0 0 6px 0;color:var(--ink)}
-  .post-card-excerpt{margin:0 0 8px 0;color:var(--muted)}
-  .post-card-meta{font-size:.9rem;color:var(--muted)}
-  .post-card-link{color:inherit;text-decoration:none}
-  .post-card-img{width:100%;height:auto;border-radius:8px;margin-bottom:8px;display:block}
-  </style>

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -62,3 +62,10 @@ footer{border-top:1px solid var(--line);padding:18px 0;color:var(--muted)}
 .review-card .stars{color:#eab308;margin-bottom:8px;font-size:14px}
 .review-card p{margin:0;color:var(--muted);font-size:15px}
 @keyframes fadeIn{from{opacity:0;transform:translateY(10px)}to{opacity:1;transform:translateY(0)}}
+.post-card{background:var(--card);border:1px solid var(--line);border-radius:14px;padding:14px 16px;box-shadow:0 6px 14px rgba(2,6,23,.06);transition:transform .08s ease}
+.post-card:hover{transform:translateY(-2px)}
+.post-card-title{margin:0 0 6px 0;color:var(--ink)}
+.post-card-excerpt{margin:0 0 8px 0;color:var(--muted)}
+.post-card-meta{font-size:.9rem;color:var(--muted)}
+.post-card-link{color:inherit;text-decoration:none}
+.post-card-img{width:100%;height:auto;border-radius:8px;margin-bottom:8px;display:block}

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -228,15 +228,6 @@ h6 {
   color: var(--muted);
   font-size: 15px;
 }
-
-.post-card-img {
-  width: 100%;
-  height: auto;
-  border-radius: 12px;
-  margin-bottom: $spacing-unit;
-  display: block;
-}
-
 .meta {
   font-size: 13px;
   color: var(--muted);
@@ -435,5 +426,46 @@ footer {
     opacity: 1;
     transform: translateY(0);
   }
+}
+
+.post-card {
+  background: var(--card);
+  border: 1px solid var(--line);
+  border-radius: 14px;
+  padding: 14px 16px;
+  box-shadow: 0 6px 14px rgba(2,6,23,.06);
+  transition: transform .08s ease;
+}
+
+.post-card:hover {
+  transform: translateY(-2px);
+}
+
+.post-card-title {
+  margin: 0 0 6px 0;
+  color: var(--ink);
+}
+
+.post-card-excerpt {
+  margin: 0 0 8px 0;
+  color: var(--muted);
+}
+
+.post-card-meta {
+  font-size: .9rem;
+  color: var(--muted);
+}
+
+.post-card-link {
+  color: inherit;
+  text-decoration: none;
+}
+
+.post-card-img {
+  width: 100%;
+  height: auto;
+  border-radius: 8px;
+  margin-bottom: 8px;
+  display: block;
 }
 


### PR DESCRIPTION
## Summary
- remove inline styling from post card include
- centralize post card styles in main.scss and compiled CSS

## Testing
- `bundle install` *(fails: Gem::Net::HTTPClientException 403 "Forbidden")*
- `bundle exec jekyll build` *(fails: bundler: command not found: jekyll)*

------
https://chatgpt.com/codex/tasks/task_e_68c1c193d8ac8321b987a80a85a87e21