### PR TITLE
refactor: relocate search styles

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -69,3 +69,9 @@ footer{border-top:1px solid var(--line);padding:18px 0;color:var(--muted)}
 .post-card-meta{font-size:.9rem;color:var(--muted)}
 .post-card-link{color:inherit;text-decoration:none}
 .post-card-img{width:100%;height:auto;border-radius:8px;margin-bottom:8px;display:block}
+#search-input{width:100%;padding:10px;border-radius:10px;border:1px solid #cbd5e1}
+#search-input::placeholder{color:var(--muted);opacity:1}
+.search-results{list-style:none;padding-left:0;margin-top:12px}
+.search-results li{padding:8px 0;border-bottom:1px solid #e2e8f0}
+.search-results a{font-weight:700}
+.search-results span{color:#334155;margin-left:6px}

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -469,3 +469,36 @@ footer {
   display: block;
 }
 
+/* Search page styles */
+#search-input {
+  width: 100%;
+  padding: 10px;
+  border-radius: 10px;
+  border: 1px solid #cbd5e1;
+}
+
+#search-input::placeholder {
+  color: var(--muted);
+  opacity: 1;
+}
+
+.search-results {
+  list-style: none;
+  padding-left: 0;
+  margin-top: 12px;
+}
+
+.search-results li {
+  padding: 8px 0;
+  border-bottom: 1px solid #e2e8f0;
+}
+
+.search-results a {
+  font-weight: 700;
+}
+
+.search-results span {
+  color: #334155;
+  margin-left: 6px;
+}
+

--- a/search.md
+++ b/search.md
@@ -19,12 +19,3 @@ permalink: /search/
     fuzzy: true
   })
 </script>
-
-<style>
-#search-input{width:100%;padding:10px;border-radius:10px;border:1px solid #cbd5e1}
-#search-input::placeholder{color:var(--muted);opacity:1}
-.search-results{list-style:none;padding-left:0;margin-top:12px}
-.search-results li{padding:8px 0;border-bottom:1px solid #e2e8f0}
-.search-results a{font-weight:700}
-.search-results span{color:#334155;margin-left:6px}
-</style>


### PR DESCRIPTION
## Summary
- remove inline style block from `search.md`
- move `#search-input` and `.search-results` styles into `assets/css/main.scss`
- update compiled `main.css` with search styles

## Testing
- `bundle install` *(fails: Gem::Net::HTTPClientException 403 "Forbidden")*
- `bundle exec jekyll build` *(fails: bundler: command not found: jekyll)*

------
https://chatgpt.com/codex/tasks/task_e_68c1c314a7e883218cf0ae2786cda803