### PR TITLE
feat: centralize post image styling

### DIFF
--- a/_posts/2025-09-09-do-we-still-need-speaking-partners.md
+++ b/_posts/2025-09-09-do-we-still-need-speaking-partners.md
@@ -8,7 +8,7 @@ excerpt: "Speaking partners used to be essential. With Falowen, you can practice
 image: https://i.imgur.com/QoevL0A.jpeg
 ---
 
-<img src="https://i.imgur.com/QoevL0A.jpeg" alt="Falowen speaking practice" style="max-width:560px;width:100%;height:auto;display:block;margin:0 auto 12px;border-radius:12px;">
+<img src="https://i.imgur.com/QoevL0A.jpeg" alt="Falowen speaking practice" class="post-img">
 
 ## The Traditional Way
 

--- a/_posts/2025-09-10-german-vocabulary-daily-habits.md
+++ b/_posts/2025-09-10-german-vocabulary-daily-habits.md
@@ -8,7 +8,7 @@ excerpt: "Small, consistent steps are the secret to mastering German vocabulary.
 image: https://i.imgur.com/2T6e8nX.jpeg
 ---
 
-<img src="https://i.imgur.com/2T6e8nX.jpeg" alt="Falowen Vocabulary Preview" loading="lazy" width="560" height="315" style="max-width:560px;width:100%;height:auto;display:block;margin:0 auto 12px;border-radius:12px;">
+<img src="https://i.imgur.com/2T6e8nX.jpeg" alt="Falowen Vocabulary Preview" loading="lazy" width="560" height="315" class="post-img">
 
 ## Why Daily Vocabulary Matters
 

--- a/_posts/2025-09-11-falowen-potential-ghana-africa-global.md
+++ b/_posts/2025-09-11-falowen-potential-ghana-africa-global.md
@@ -8,7 +8,7 @@ excerpt: "From classrooms in Accra to learners worldwide, Falowen has the potent
 image: https://i.imgur.com/7uJRrbr.png
 ---
 
-<img src="https://i.imgur.com/7uJRrbr.png" alt="Falowen Global Potential" style="max-width:560px;width:100%;height:auto;display:block;margin:0 auto 12px;border-radius:12px;">
+<img src="https://i.imgur.com/7uJRrbr.png" alt="Falowen Global Potential" class="post-img">
 
 ## From Ghanaian Classrooms to Global Stages
 

--- a/_posts/2025-09-12-how-long-to-practice-german-daily.md
+++ b/_posts/2025-09-12-how-long-to-practice-german-daily.md
@@ -8,7 +8,7 @@ excerpt: "Falowen recommends one focused hour a day—or 1 hour for 3 days at A2
 image: https://i.imgur.com/GxUKnUw.jpeg
 ---
 
-<img src="https://i.imgur.com/GxUKnUw.jpeg" alt="Daily German practice with Falowen" style="max-width:560px;width:100%;height:auto;display:block;margin:0 auto 12px;border-radius:12px;">
+<img src="https://i.imgur.com/GxUKnUw.jpeg" alt="Daily German practice with Falowen" class="post-img">
 
 ## The Daily Practice Question
 

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -469,6 +469,15 @@ footer {
   display: block;
 }
 
+.post-img {
+  max-width: 560px;
+  width: 100%;
+  height: auto;
+  display: block;
+  margin: 0 auto 12px;
+  border-radius: 12px;
+}
+
 /* Search page styles */
 #search-input {
   width: 100%;


### PR DESCRIPTION
## Summary
- create reusable `.post-img` class with shared image dimensions and spacing
- replace inline `style` attributes in blog posts with `class="post-img"`

## Testing
- `bundle exec jekyll build` *(fails: bundler: command not found: jekyll)*
- `bundle install` *(fails: Gem::Net::HTTPClientException 403 "Forbidden")*


------
https://chatgpt.com/codex/tasks/task_e_68c1c3df68308321a100b2b14763c1ce