### PR TITLE
Add robots meta tag and tag page directives

### DIFF
--- a/_includes/head-custom.html
+++ b/_includes/head-custom.html
@@ -4,6 +4,10 @@
 <meta name="description" content="{{ site.description | escape }}">
 {% endif %}
 
+{% if page.robots %}
+<meta name="robots" content="{{ page.robots }}">
+{% endif %}
+
 <link rel="icon" href="https://i.imgur.com/mcrrGfd.png" />
 
 <meta property="og:title" content="{{ page.title | default: site.title | escape }}">

--- a/tags.md
+++ b/tags.md
@@ -2,6 +2,7 @@
 layout: page
 title: Tags
 permalink: /tags/
+robots: noindex,follow
 ---
 
 <ul>


### PR DESCRIPTION
## Summary
- Add conditional robots meta tag in head
- Set tag index to `noindex,follow` for robots

## Testing
- `bundle install` *(fails: 403 Forbidden)*
- `bundle exec jekyll build` *(fails: command not found: jekyll)*

------
https://chatgpt.com/codex/tasks/task_e_68c1c7b99e08832199d1e00da128e77d