### PR TITLE
Add fade-in transitions for tab panels

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -18,5 +18,6 @@
     </main>
     {% include footer.html %}
     <script src="{{ '/assets/js/theme-toggle.js' | relative_url }}"></script>
+    <script src="{{ '/assets/js/tabs.js' | relative_url }}"></script>
   </body>
 </html>

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -75,4 +75,4 @@ footer{border-top:1px solid var(--line);padding:18px 0;color:var(--muted)}
 .search-results li{padding:8px 0;border-bottom:1px solid #e2e8f0}
 .search-results a{font-weight:700}
 .search-results span{color:#334155;margin-left:6px}
-.cta{margin:24px 0;text-align:center}.cta-button{display:inline-block;padding:12px 24px;background:var(--brand);color:#fff;border-radius:8px;text-decoration:none;font-weight:600}.cta-button:hover{opacity:.9}
+.cta{margin:24px 0;text-align:center}.cta-button{display:inline-block;padding:12px 24px;background:var(--brand);color:#fff;border-radius:8px;text-decoration:none;font-weight:600}.cta-button:hover{opacity:.9}.fx-tab-panel{opacity:0;transition:opacity .2s ease}[role=tabpanel]:not([hidden]){opacity:1}

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -552,3 +552,13 @@ footer {
   }
 }
 
+/* Tab panels */
+.fx-tab-panel {
+  opacity: 0;
+  transition: opacity .2s ease;
+}
+
+[role="tabpanel"]:not([hidden]) {
+  opacity: 1;
+}
+

--- a/assets/js/tabs.js
+++ b/assets/js/tabs.js
@@ -1,0 +1,30 @@
+(function() {
+  const tabLists = document.querySelectorAll('[role="tablist"]');
+  tabLists.forEach(list => {
+    const tabs = list.querySelectorAll('[role="tab"]');
+    tabs.forEach(tab => {
+      tab.addEventListener('click', () => {
+        const targetId = tab.getAttribute('aria-controls');
+        if (!targetId) return;
+
+        tabs.forEach(t => {
+          t.setAttribute('aria-selected', 'false');
+          const id = t.getAttribute('aria-controls');
+          if (!id) return;
+          const panel = document.getElementById(id);
+          if (!panel) return;
+          panel.setAttribute('hidden', '');
+          panel.classList.remove('fx-tab-panel--active');
+        });
+
+        tab.setAttribute('aria-selected', 'true');
+        const panel = document.getElementById(targetId);
+        if (!panel) return;
+        panel.removeAttribute('hidden');
+        requestAnimationFrame(() => {
+          panel.classList.add('fx-tab-panel--active');
+        });
+      });
+    });
+  });
+})();


### PR DESCRIPTION
## Summary
- add fade-in styles for tab panels and active state
- implement JavaScript handler to toggle tab panels with opacity transition
- load new tab script in default layout

## Testing
- `npm test` *(fails: Could not read package.json)*
- `bundle exec jekyll build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c1cac1e0208321b976ccfd96ffaee0