### PR TITLE
Add testimonials section before highlights

### DIFF
--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -1,3 +1,8 @@
+<section id="testimonials" class="wrap section">
+  <h2>What students say</h2>
+  <div class="reviews-container"></div>
+</section>
+
 <!-- Feature highlights (with tabs) -->
 <section class="wrap section">
   <h2>Highlights</h2>


### PR DESCRIPTION
## Summary
- add new testimonials section at top of home layout before highlights

## Testing
- `bundle exec jekyll build` *(fails: bundler: command not found: jekyll)*
- `bundle install` *(fails: Gem::Net::HTTPClientException 403 "Forbidden" installing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68c1d1a3e11c8321bf5f946d14626692