### PR TITLE
Conditionally load testimonials script

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -19,5 +19,8 @@
     {% include footer.html %}
     <script src="{{ '/assets/js/theme-toggle.js' | relative_url }}"></script>
     <script src="{{ '/assets/js/tabs.js' | relative_url }}"></script>
+    {% if page.testimonials %}
+    <script src="{{ '/assets/js/reviews.js' | relative_url }}"></script>
+    {% endif %}
   </body>
 </html>

--- a/index.md
+++ b/index.md
@@ -1,3 +1,4 @@
 ---
 layout: home
+testimonials: true
 ---


### PR DESCRIPTION
## Summary
- Load `reviews.js` after existing scripts when `page.testimonials` is set
- Mark home page to trigger testimonials script

## Testing
- `bundle install` *(fails: Gem::Net::HTTPClientException 403 "Forbidden")*
- `bundle exec jekyll build` *(fails: bundler: command not found: jekyll)*

------
https://chatgpt.com/codex/tasks/task_e_68c1d39817788321945a7f3c45565bce