### PR TITLE
Remove hero text and CTA from home layout

### DIFF
--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -23,9 +23,6 @@
   <!-- Hero -->
   <header class="hero">
     <div class="wrap">
-      <h1>Falowen Blog</h1>
-      <p>Course books, assignments, results and resources, exam mode, custom chat, vocab and Schreiben trainers—all in one place.</p>
-      <a class="cta" href="https://falowen.app" target="_blank" rel="noopener">Try Falowen <span class="cta-icon">→</span></a>
     </div>
   </header>
 


### PR DESCRIPTION
## Summary
- remove heading, description, and CTA link from hero section

## Testing
- `bundle exec jekyll build` *(fails: command not found: jekyll)*
- `bundle install` *(fails: Gem::Net::HTTPClientException 403 "Forbidden" installing gems)*

------
https://chatgpt.com/codex/tasks/task_e_68c1ddbee904832191a5486123a9173b