### PR TITLE
feat: refresh brand color

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -1,6 +1,6 @@
 @import url("https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700;900&family=Poppins:wght@400;500;600;700&display=swap");
 :root{
-  --brand:#25317e;
+  --brand:#ff6a00;
   --bg:#f3f7fb;
   --ink:#1c2440;
   --muted:#334155;
@@ -8,7 +8,7 @@
   --ring:rgba(37,49,126,.18);
   --line:rgba(148,163,184,.35);
 }
-[data-theme=dark]{--brand:#25317e;--bg:#1c2440;--ink:#f3f7fb;--muted:#cbd5e1;--card:#334155;--ring:rgba(37,49,126,.5);--line:rgba(148,163,184,.2)}
+[data-theme=dark]{--brand:#ff6a00;--bg:#1c2440;--ink:#f3f7fb;--muted:#cbd5e1;--card:#334155;--ring:rgba(37,49,126,.5);--line:rgba(148,163,184,.2)}
 html,body{margin:0;padding:0;background:var(--bg);color:var(--ink);font-family:Inter,system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif;font-weight:400;line-height:1.6}
 img{max-width:100%;height:auto}
 h1,h2,h3,h4,h5,h6{font-family:Poppins,Inter,system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif;line-height:1.3}
@@ -22,8 +22,8 @@ h6{font-size:.875rem;font-weight:500}
 .hero{background:linear-gradient(180deg,var(--bg),rgba(243,247,251,0));border-top:6px solid var(--brand);padding:44px 0 22px}
 .hero h1{margin:0 0 10px 0;font-size:clamp(28px,4vw,44px);line-height:1.1;color:var(--ink);font-weight:700}
 .hero p{margin:0 0 16px 0;color:var(--muted);font-size:clamp(16px,2vw,18px)}
-.cta{display:inline-flex;align-items:center;background:linear-gradient(135deg,#3140a5,#25317e);color:#fff;text-decoration:none;padding:12px 16px;border-radius:12px;font-weight:800;border:1px solid rgba(37,49,126,.9);box-shadow:0 4px 14px rgba(37,49,126,.25);transition:background .3s ease,box-shadow .3s ease}
-.cta:hover{background:linear-gradient(135deg,#3648b9,#25317e);box-shadow:0 6px 18px rgba(37,49,126,.35)}
+.cta{display:inline-flex;align-items:center;background:linear-gradient(135deg,#ff8c33,var(--brand));color:#fff;text-decoration:none;padding:12px 16px;border-radius:12px;font-weight:800;border:1px solid rgba(255,106,0,.9);box-shadow:0 4px 14px rgba(255,106,0,.25);transition:background .3s ease,box-shadow .3s ease}
+.cta:hover{background:linear-gradient(135deg,#ffa24d,var(--brand));box-shadow:0 6px 18px rgba(255,106,0,.35)}
 .cta-icon{margin-left:8px;display:inline-block;line-height:1;font-size:1.25em}
 .features{display:flex;flex-wrap:wrap;justify-content:center;gap:12px;margin:18px 0 8px}
 .feature{display:flex;align-items:flex-start;gap:8px;background:var(--card);border:1px solid var(--line);border-radius:14px;padding:10px 12px;box-shadow:0 6px 14px rgba(2,6,23,.06);color:inherit;text-decoration:none}
@@ -48,8 +48,8 @@ h6{font-size:.875rem;font-weight:500}
 .topnav-list{display:flex;flex-direction:row;align-items:center;gap:14px;list-style:none;margin:0;padding:0}
 .topnav-list li{margin:0}
 .topnav-list a,.topnav-list button{color:var(--brand);text-decoration:none;font-weight:700;padding:6px 8px;border-radius:6px;transition:background .2s,color .2s;background:none;border:none;cursor:pointer}
-.topnav-list a:hover,.topnav-list a:focus-visible,.topnav-list button:hover,.topnav-list button:focus-visible{background:#3140a5;color:#fff}
-.topnav-list li.active a{background:#25317e;color:#fff}
+.topnav-list a:hover,.topnav-list a:focus-visible,.topnav-list button:hover,.topnav-list button:focus-visible{background:var(--brand);color:#fff}
+.topnav-list li.active a{background:var(--brand);color:#fff}
 @media (max-width:640px){.topnav-toggle{display:block}.topnav-list{display:none;flex-direction:column;position:absolute;top:100%;right:0;background:var(--card);border:1px solid var(--line);padding:8px 0;border-radius:8px;z-index:10}.topnav-list.open{display:flex}}
 .post-nav{display:flex;justify-content:space-between;margin:16px 0}
 .post-nav a{color:var(--brand);text-decoration:none;font-weight:700}


### PR DESCRIPTION
## Summary
- switch brand variable to a vivid orange for higher contrast
- update CTA and navigation styles to use the brand variable

## Testing
- `bundle exec jekyll build` *(fails: bundler: command not found: jekyll)*
- `bundle install` *(fails: Gem::Net::HTTPClientException 403 "Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68c1e146c3b883219cbf672f73c914d8