### PR TITLE
Limit home page posts and improve mobile spacing

### DIFF
--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -30,7 +30,7 @@
   <section class="wrap section">
     <h2>Latest articles</h2>
     <div class="latest">
-      {% for post in site.posts | slice: 0, 3 %}
+      {% for post in site.posts limit: 3 %}
       <article class="card">
         <a href="{{ post.url | relative_url }}">
           {% if post.image %}

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -32,7 +32,8 @@ h6{font-size:.875rem;font-weight:500}
 .feature img{width:32px;margin-right:8px}
 .section{padding:10px 0 28px}
 .section h2{margin:8px 0 10px 0;color:var(--ink);font-size:24px}
-.latest{display:flex;gap:14px}
+.latest{display:flex;flex-wrap:wrap;gap:14px}
+@media (max-width:640px){.latest{flex-direction:column}}
 .card{background:var(--card);border:1px solid var(--line);border-radius:14px;padding:14px 16px;box-shadow:0 6px 14px rgba(2,6,23,.06);display:flex;flex-direction:column;gap:8px;flex:1}
 .card a{color:inherit;text-decoration:none}
 .card h3{margin:0;color:var(--ink);font-size:18px}


### PR DESCRIPTION
## Summary
- show only three recent articles on the front page
- tweak mobile layout to stack latest-post cards for better spacing

## Testing
- `bundle exec jekyll build` *(fails: bundler: command not found: jekyll)*

------
https://chatgpt.com/codex/tasks/task_e_68c1e51249a483218091650265240399