### PR TITLE
Add social share buttons to posts

### DIFF
--- a/_includes/share.html
+++ b/_includes/share.html
@@ -1,0 +1,6 @@
+{% assign post_url = site.url | append: page.url | url_encode %}
+<div class="post-share">
+  <a href="https://www.facebook.com/sharer/sharer.php?u={{ post_url }}" target="_blank" rel="noopener">Facebook</a>
+  <a href="https://wa.me/?text={{ post_url }}" target="_blank" rel="noopener">WhatsApp</a>
+  <a href="https://twitter.com/intent/tweet?url={{ post_url }}" target="_blank" rel="noopener">Twitter</a>
+</div>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -21,6 +21,8 @@ layout: default
 
     {% include cta.html %}
 
+    {% include share.html %}
+
     <nav class="post-nav">
       {% if page.previous %}
         <a class="prev" href="{{ page.previous.url | relative_url }}">&laquo; {{ page.previous.title }}</a>

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -76,4 +76,4 @@ footer{border-top:1px solid var(--line);padding:18px 0;color:var(--muted)}
 .search-results li{padding:8px 0;border-bottom:1px solid #e2e8f0}
 .search-results a{font-weight:700}
 .search-results span{color:#334155;margin-left:6px}
-.cta{margin:24px 0;text-align:center}.cta-button{display:inline-block;padding:12px 24px;background:var(--brand);color:#fff;border-radius:8px;text-decoration:none;font-weight:600}.cta-button:hover{opacity:.9}.fx-tab-panel{opacity:0;transition:opacity .2s ease}[role=tabpanel]:not([hidden]){opacity:1}
+.cta{margin:24px 0;text-align:center}.cta-button{display:inline-block;padding:12px 24px;background:var(--brand);color:#fff;border-radius:8px;text-decoration:none;font-weight:600}.cta-button:hover{opacity:.9}.fx-tab-panel{opacity:0;transition:opacity .2s ease}[role=tabpanel]:not([hidden]){opacity:1}.post-share{margin-top:1rem}.post-share a{margin-right:.5rem}

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -56,3 +56,11 @@
 .fx-tab-panel{ opacity: 0; transition: opacity .2s ease; }
 [role="tabpanel"]:not([hidden]){ opacity: 1; }
 /* ==== /Fancy Tabs ==== */
+
+.post-share {
+  margin-top: 1rem;
+}
+
+.post-share a {
+  margin-right: 0.5rem;
+}


### PR DESCRIPTION
## Summary
- add reusable share.html include with Facebook, WhatsApp and Twitter links
- insert share block at end of posts
- style share links with spacing in SCSS and CSS

## Testing
- ⚠️ `bundle exec jekyll build` *(failed: bundler could not install gems, 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c1e7f9e8808321ba7e94c253f3cbbf