### PR TITLE
Add RSS feed link in head for global visibility

### DIFF
--- a/_includes/head-custom.html
+++ b/_includes/head-custom.html
@@ -10,6 +10,13 @@
 
 <link rel="icon" href="https://i.imgur.com/mcrrGfd.png" />
 
+<link
+  rel="feed"
+  type="application/rss+xml"
+  title="{{ site.title }}"
+  href="{{ '/feed.xml' | absolute_url }}"
+>
+
 <meta property="og:title" content="{{ page.title | default: site.title | escape }}">
 <meta property="og:description" content="{{ page.excerpt | strip_html | strip_newlines | truncate: 160 | default: site.description | escape }}">
 <meta property="og:url" content="{{ page.url | absolute_url }}">


### PR DESCRIPTION
## Summary
- Declare RSS feed in custom head include so browsers can detect the site's feed

## Testing
- `bundle exec jekyll build` *(fails: bundler: command not found: jekyll)*
- `bundle install` *(fails: Gem::Net::HTTPClientException 403 "Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68c41536d68c832199538db289e07b4d