### PR TITLE
Move post image style to global stylesheet

### DIFF
--- a/_posts/2025-09-09-falowen-your-german-conversation-partner.md
+++ b/_posts/2025-09-09-falowen-your-german-conversation-partner.md
@@ -9,14 +9,6 @@ image: https://i.imgur.com/pqXoqSC.png
 ---
 
 <style>
-.post-img{
-  max-width:560px;
-  width:100%;
-  height:auto;
-  display:block;
-  margin:0 auto 12px;
-  border-radius:12px;
-}
 .feature-list li, .why-list li{ margin:6px 0 }
 .callout{ border-left:4px solid #e2e8f0; background:#f8fafc; padding:10px 12px; color:#475569; margin:12px 0 }
 .btn{ display:inline-block; background:#25317e; color:#fff; text-decoration:none; padding:10px 14px; border-radius:12px; margin:8px 0 }

--- a/_posts/2025-09-10-german-vocabulary-daily-habits.md
+++ b/_posts/2025-09-10-german-vocabulary-daily-habits.md
@@ -9,14 +9,6 @@ image: https://i.imgur.com/2T6e8nX.jpeg
 ---
 
 <style>
-.post-img{
-  max-width:560px;
-  width:100%;
-  height:auto;
-  display:block;
-  margin:0 auto 12px;
-  border-radius:12px;
-}
 .feature-list li{margin:6px 0}
 </style>
 

--- a/_posts/2025-09-11-falowen-potential-ghana-africa-global.md
+++ b/_posts/2025-09-11-falowen-potential-ghana-africa-global.md
@@ -9,14 +9,6 @@ image: https://i.imgur.com/hZMlxWK.jpeg
 ---
 
 <style>
-.post-img{
-  max-width:560px;
-  width:100%;
-  height:auto;
-  display:block;
-  margin:0 auto 12px;
-  border-radius:12px;
-}
 .stats{ display:flex; gap:16px; flex-wrap:wrap; margin:12px 0 8px; }
 .stat-card{
   flex:1; min-width:180px; padding:10px 12px;

--- a/about.md
+++ b/about.md
@@ -6,10 +6,6 @@ permalink: /about/
 
 # About the Falowen Blog
 
-<style>
-.post-img{max-width:720px;width:100%;height:auto;border-radius:12px;display:block;margin:0 auto 12px}
-</style>
-
 <img src="https://i.imgur.com/peGxlkO.png" alt="About Falowen" class="post-img">
 
 The **Falowen Blog** is where we share stories, tips, and updates from **Learn Language Education Academy** and the **Falowen app**.

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -77,3 +77,4 @@ footer{border-top:1px solid var(--line);padding:18px 0;color:var(--muted)}
 .search-results a{font-weight:700}
 .search-results span{color:#334155;margin-left:6px}
 .cta{margin:24px 0;text-align:center}.cta-button{display:inline-block;padding:12px 24px;background:var(--brand);color:#fff;border-radius:8px;text-decoration:none;font-weight:600}.cta-button:hover{opacity:.9}.fx-tab-panel{opacity:0;transition:opacity .2s ease}[role=tabpanel]:not([hidden]){opacity:1}.post-share{margin-top:1rem}.post-share a{margin-right:.5rem}
+.post-img{max-width:100%;width:100%;height:auto}

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -64,3 +64,9 @@
 .post-share a {
   margin-right: 0.5rem;
 }
+
+.post-img {
+  max-width: 100%;
+  width: 100%;
+  height: auto;
+}


### PR DESCRIPTION
## Summary
- remove inline `.post-img` styles from posts and about page
- add global `.post-img` rule in main stylesheet
- confirm site layout loads compiled CSS for shared styling

## Testing
- `bundle install` *(fails: Gem::Net::HTTPClientException 403 "Forbidden")*
- `bundle exec jekyll build` *(fails: command not found: jekyll)*

------
https://chatgpt.com/codex/tasks/task_e_68c417e8a20483219bdd79a11bb8b166