### PR TITLE
Use layout to render post hero images

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -14,10 +14,19 @@ layout: default
       {%- endif -%}
     </p>
   </header>
+  {% if page.image %}
+    <img
+      src="{{ page.image }}"
+      alt="{{ page.image_alt | default: page.title }}"
+      width="{{ page.image_width | default: 600 }}"
+      height="{{ page.image_height | default: 400 }}"
+      loading="eager"
+      class="post-img">
+  {% endif %}
 
-    <div class="post-content e-content" itemprop="articleBody">
-      {{ content }}
-    </div>
+  <div class="post-content e-content" itemprop="articleBody">
+    {{ content }}
+  </div>
 
     {% include cta.html %}
 

--- a/_posts/2025-09-09-do-we-still-need-speaking-partners.md
+++ b/_posts/2025-09-09-do-we-still-need-speaking-partners.md
@@ -7,9 +7,6 @@ categories: [Debate]
 excerpt: "Speaking partners used to be essential. With Falowen, you can practice anytime, anywhere, faster than the traditional way."
 image: https://i.imgur.com/QoevL0A.jpeg
 ---
-
-<img src="https://i.imgur.com/QoevL0A.jpeg" alt="Falowen speaking practice" class="post-img">
-
 ## The Traditional Way
 
 For years, language learners were told to find a speaking partner to become fluent.  

--- a/_posts/2025-09-09-falowen-your-german-conversation-partner.md
+++ b/_posts/2025-09-09-falowen-your-german-conversation-partner.md
@@ -14,8 +14,6 @@ image: https://i.imgur.com/pqXoqSC.png
 .btn{ display:inline-block; background:#25317e; color:#fff; text-decoration:none; padding:10px 14px; border-radius:12px; margin:8px 0 }
 </style>
 
-<img src="https://i.imgur.com/pqXoqSC.png" alt="Falowen app conversation and practice overview" class="post-img">
-
 ## The Story Behind Falowen
 
 Falowen was born out of a real classroom need. At Learn Language Education Academy in Accra, Ghana, we saw students preparing for Goethe A1 and A2 who worked hard in class but lacked structured practice tools at home.

--- a/_posts/2025-09-10-german-vocabulary-daily-habits.md
+++ b/_posts/2025-09-10-german-vocabulary-daily-habits.md
@@ -6,13 +6,13 @@ tags: [falowen, german, vocabulary, tips, learning]
 categories: [Tips]
 excerpt: "Small, consistent steps are the secret to mastering German vocabulary. Learn how Falowen helps you build habits that last."
 image: https://i.imgur.com/2T6e8nX.jpeg
+image_width: 560
+image_height: 315
 ---
 
 <style>
 .feature-list li{margin:6px 0}
 </style>
-
-<img src="https://i.imgur.com/2T6e8nX.jpeg" alt="Falowen vocabulary practice on mobile" loading="lazy" width="560" height="315" class="post-img">
 
 ## Why Daily Vocabulary Matters
 

--- a/_posts/2025-09-11-falowen-potential-ghana-africa-global.md
+++ b/_posts/2025-09-11-falowen-potential-ghana-africa-global.md
@@ -22,9 +22,6 @@ image: https://i.imgur.com/hZMlxWK.jpeg
 }
 </style>
 
-<!-- TOP IMAGE -->
-<img src="https://i.imgur.com/hZMlxWK.jpeg" alt="Falowen vision and growth from Ghana to a global audience" class="post-img">
-
 <div class="stats">
   <div class="stat-card">
     <strong>500+ passes</strong><br><small>Goethe A1 to A2 and beyond</small>

--- a/_posts/2025-09-12-how-long-to-practice-german-daily.md
+++ b/_posts/2025-09-12-how-long-to-practice-german-daily.md
@@ -7,9 +7,6 @@ categories: [Tips]
 excerpt: "Falowen recommends one focused hour a day—or 1 hour for 3 days at A2+—with deep understanding of each task. Here’s how to make every minute count, even when you only have 15–30 minutes."
 image: https://i.imgur.com/GxUKnUw.jpeg
 ---
-
-<img src="https://i.imgur.com/GxUKnUw.jpeg" alt="Daily German practice with Falowen" class="post-img">
-
 ## The Daily Practice Question
 
 “How much time should I spend on German each day?”  


### PR DESCRIPTION
## Summary
- Render hero images in the post layout using `page.image` with eager loading and size attributes.
- Remove manually inserted hero images from posts.
- Record explicit hero dimensions for the vocabulary habits article.

## Testing
- `bundle exec jekyll build` *(fails: bundler could not find `jekyll`)*
- `bundle install` *(fails: Gem::Net::HTTPClientException 403 "Forbidden" while fetching gems)*

------
https://chatgpt.com/codex/tasks/task_e_68c418cbe9748321bdec0df3bbc3546a