### PR TITLE
feat: add article schema

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -54,3 +54,26 @@ layout: default
   {% endif %}
   {% include related-posts.html %}
 </article>
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Article",
+  "mainEntityOfPage": {
+    "@type": "WebPage",
+    "@id": "{{ page.url | absolute_url }}"
+  },
+  "headline": {{ page.title | jsonify }}{% if page.excerpt %},
+  "description": {{ page.excerpt | strip_html | strip_newlines | jsonify }}{% endif %}{% if page.image %},
+  "image": {{ page.image | absolute_url | jsonify }}{% endif %},
+  "datePublished": "{{ page.date | date_to_xmlschema }}",
+  "dateModified": "{{ page.last_modified_at | default: page.date | date_to_xmlschema }}"{% if page.author %},
+  "author": {
+    "@type": "Person",
+    "name": {{ page.author | jsonify }}
+  }{% endif %},
+  "publisher": {
+    "@type": "Organization",
+    "name": {{ site.title | jsonify }}
+  }
+}
+</script>


### PR DESCRIPTION
## Summary
- add JSON-LD article structured data for blog posts

## Testing
- `bundle exec jekyll build` *(fails: bundler: command not found: jekyll)*

------
https://chatgpt.com/codex/tasks/task_e_68c4191595fc83219f8fe99fc9bb9c59