### PR TITLE
Add sitemap plugin configuration and robots.txt

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -11,7 +11,7 @@ header_pages:
 plugins:
   - jekyll-feed
   - jekyll-seo-tag
-  - jekyll-sitemap
+  - jekyll-sitemap # generate sitemap.xml
   - jekyll-paginate-v2
 future: true
 # twitter_username: falowen

--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,3 @@
+User-agent: *
+Allow: /
+Sitemap: https://blog.falowen.app/sitemap.xml


### PR DESCRIPTION
## Summary
- ensure jekyll-sitemap plugin is noted in config
- add robots.txt pointing to generated sitemap for crawlers

## Testing
- `bundle exec jekyll build` *(fails: command not found: jekyll)*
- `bundle install` *(fails: Gem::Net::HTTPClientException 403 "Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68c41a191aa48321b05a2555f50b6f85