### PR TITLE
Use initials for testimonial names

### DIFF
--- a/assets/js/reviews.js
+++ b/assets/js/reviews.js
@@ -3,6 +3,13 @@ const SHEET_GID = '0'; // worksheet gid
 
 const endpoint = `https://docs.google.com/spreadsheets/d/${SHEET_ID}/gviz/tq?gid=${SHEET_GID}`;
 
+function toInitials(name = '') {
+  if (!name) return '';
+  const parts = name.trim().split(/\s+/).filter(Boolean);
+  if (parts.length === 0) return '';
+  return parts.map(p => p[0].toUpperCase() + '.').join(' ');
+}
+
 async function fetchReviews() {
   const container = document.querySelector('#testimonials .reviews-container');
   if (!container) return;
@@ -43,7 +50,7 @@ function renderReviews(reviews, container) {
     card.className = 'review-card';
 
     const name = document.createElement('h3');
-    name.textContent = r.student_name;
+    name.textContent = toInitials(r.student_name);
     card.appendChild(name);
 
     const stars = document.createElement('div');


### PR DESCRIPTION
## Summary
- add `toInitials` helper to convert full names to initials
- show initials instead of full student names in testimonials

## Testing
- `node -e "const fs=require('fs'); const vm=require('vm'); const code=fs.readFileSync('assets/js/reviews.js','utf8'); const sandbox={document:{querySelector:()=>null}}; vm.createContext(sandbox); vm.runInContext(code, sandbox); console.log(sandbox.toInitials('Jane Doe')); console.log(sandbox.toInitials('Madonna')); console.log(sandbox.toInitials(''));"`
- `node -e "const fs=require('fs'); const vm=require('vm'); const code=fs.readFileSync('assets/js/reviews.js','utf8'); const container={innerHTML:'', children:[], appendChild(child){this.children.push(child);}}; const document={ querySelector:()=>container, createElement:tag=>({tagName:tag, className:'', textContent:'', children:[], setAttribute:()=>{}, appendChild(child){this.children.push(child);}})}; const sandbox={document}; vm.createContext(sandbox); vm.runInContext(code, sandbox); sandbox.renderReviews([{student_name:'Jane Doe', rating:5, review_text:''},{student_name:'Madonna', rating:4, review_text:''}], container); console.log(container.children[0].children[0].textContent + '|' + container.children[1].children[0].textContent);"`
- `bundle install` *(fails: Gem::Net::HTTPClientException 403 "Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68c422a3e7888321b365e4251a1124dc