### PR TITLE
Add toggle for giscus comments configuration

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -18,6 +18,7 @@ future: true
 github_username: falowen
 
 giscus:
+  enabled: false
   repo: "owner/repo"
   repo_id: "YOUR_REPO_ID"
   category: "General"

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -41,20 +41,21 @@ layout: default
     {% endif %}
   </nav>
 
-  {% if site.giscus and site.giscus.repo %}
+  {% assign giscus = site.giscus %}
+  {% if giscus and giscus.enabled and giscus.repo and giscus.repo_id and giscus.category_id %}
     <section id="comments">
       <div id="giscus_thread"></div>
       <script src="https://giscus.app/client.js"
-              data-repo="{{ site.giscus.repo }}"
-              data-repo-id="{{ site.giscus.repo_id }}"
-              data-category="{{ site.giscus.category }}"
-              data-category-id="{{ site.giscus.category_id }}"
+              data-repo="{{ giscus.repo }}"
+              data-repo-id="{{ giscus.repo_id }}"
+              data-category="{{ giscus.category }}"
+              data-category-id="{{ giscus.category_id }}"
               data-mapping="pathname"
               data-reactions-enabled="1"
               data-emit-metadata="0"
               data-input-position="bottom"
-              data-theme="{{ site.giscus.theme | default: 'light' }}"
-              data-lang="{{ site.giscus.lang | default: 'en' }}"
+              data-theme="{{ giscus.theme | default: 'light' }}"
+              data-lang="{{ giscus.lang | default: 'en' }}"
               crossorigin="anonymous"
               async>
       </script>


### PR DESCRIPTION
## Summary
- add an `enabled` toggle to the giscus configuration so placeholder values are disabled by default
- only render the giscus comments embed when the flag is enabled and the required identifiers are present

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d817d051b88321ae65e4e9eb8d396b