### PR TITLE
Normalize Unsplash URLs, use normalized images in template/JSON-LD, and update daily post generator content

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -14,9 +14,15 @@ layout: default
       {%- endif -%}
     </p>
   </header>
-  {% if page.image %}
+  {% assign post_image = page.image %}
+  {% if post_image and post_image contains "https://unsplash.com/s/photos/" %}
+    {% assign unsplash_query = post_image | remove: "https://unsplash.com/s/photos/" | replace: "-", "," %}
+    {% assign post_image = "https://source.unsplash.com/featured/?" | append: unsplash_query %}
+  {% endif %}
+
+  {% if post_image %}
     <img
-      src="{{ page.image }}"
+      src="{{ post_image }}"
       alt="{{ page.image_alt | default: page.title }}"
       width="{{ page.image_width | default: 600 }}"
       height="{{ page.image_height | default: 400 }}"
@@ -75,8 +81,8 @@ layout: default
     "@id": "{{ page.url | absolute_url }}"
   },
   "headline": {{ page.title | jsonify }}{% if page.excerpt %},
-  "description": {{ page.excerpt | strip_html | strip_newlines | jsonify }}{% endif %}{% if page.image %},
-  "image": {{ page.image | absolute_url | jsonify }}{% endif %},
+  "description": {{ page.excerpt | strip_html | strip_newlines | jsonify }}{% endif %}{% if post_image %},
+  "image": {{ post_image | absolute_url | jsonify }}{% endif %},
   "datePublished": "{{ page.date | date_to_xmlschema }}",
   "dateModified": "{{ page.last_modified_at | default: page.date | date_to_xmlschema }}"{% if page.author %},
   "author": {

--- a/_posts/2026-04-15-why-learning-german-in-ghana-is-a-smart-move.md
+++ b/_posts/2026-04-15-why-learning-german-in-ghana-is-a-smart-move.md
@@ -5,7 +5,7 @@ date: 2026-04-15
 tags: [falowen, german, 30-day-blog, why-learning-german-in-ghana-is-a-smart-move]
 categories: [German Learning]
 excerpt: "Discover how learning German in Ghana can open doors to study, work, and international opportunities."
-image: https://unsplash.com/s/photos/student-studying-laptop
+image: https://source.unsplash.com/featured/?student,studying,laptop
 image_alt: "Why Learning German in Ghana Is a Smart Move"
 permalink: /why-learning-german-in-ghana-is-a-smart-move/
 seo:
@@ -13,10 +13,10 @@ seo:
   description: "Learn why studying German in Ghana is a smart move for education, work, and travel. Join Learn Language Education Academy with Falowen."
 ---
 ## Why this topic matters
-Discover how learning German in Ghana can open doors to study, work, and international opportunities.
+Learn German in Ghana is now known as **Learn Language Education Academy**. This 30-day series is designed to help more students discover the school, understand the training path, and sign up through Falowen and the academy.
 
 ## What you will learn
-- **Focus:** Benefits of learning German for study, work, and travel
+- **Focus:** How the academy trains students to speak German confidently and prepare for Goethe exams
 - **Keyword to remember:** learn German in Ghana
 - **Category:** German Learning
 
@@ -24,20 +24,20 @@ Discover how learning German in Ghana can open doors to study, work, and interna
 Day 1/30 reminder: Today, choose one tiny action and complete it before the day ends.
 
 ## Reading lesson (short and practical)
-If you are working on **learn German in Ghana**, the main goal is to move from memorizing words to using them naturally in short conversations.
-This lesson focuses on **Benefits of learning German for study, work, and travel** so you can build confidence with practical German for daily life, school, work, or travel.
-Try to study this post actively: read once, read again out loud, and then close the page and recreate the core idea in your own words.
+At Learn Language Education Academy (formerly Learn German in Ghana), the goal is practical progress: students learn to use German in real conversation and prepare step by step for Goethe exams.
+The course structure combines vocabulary, speaking practice, listening, and exam-focused drills so learners build both fluency and test readiness.
+To study actively, read once, read again out loud, then summarize the lesson in your own words.
 
 ## Mini examples you can copy
-- **Starter line:** Ich lerne heute etwas über *learn German in Ghana*.
-- **Question line:** Kannst du mir ein einfaches Beispiel geben?
-- **Confidence line:** Jeden Tag mache ich kleine Fortschritte auf Deutsch.
+- Learning German now helps students build confidence before they arrive in Germany.
+- German study also introduces students to new cultures and international communication.
+- Strong German preparation can support students working toward visa and relocation requirements.
 
 ## Falowen angle
-Show how Falowen and Learn Language Education Academy make German accessible
+Falowen is a German learning app built by Ghanaians to help students progress faster. It combines AI learning tools, a built syllabus, structured assignments, and a progress tracker that has helped many students prepare for and pass their Goethe exams.
 
 ## Quick practice task
-Write 4-6 short German lines around **learn German in Ghana** and say them out loud twice. If possible, send them to your tutor for feedback.
+Are you ready to start your German journey? Sign up on Falowen today, follow the syllabus step by step, and begin building real progress toward your study, travel, and visa goals.
 
 ## 5-minute revision plan
 - Minute 1: Review the keyword and focus of today's lesson.
@@ -47,4 +47,4 @@ Write 4-6 short German lines around **learn German in Ghana** and say them out l
 - Minute 5: Write one follow-up sentence to expand your idea.
 
 ## Call to action
-Register now at Learn Language Education Academy and start learning German with Falowen.
+Sign up on Falowen and join Learn Language Education Academy to start structured German training and Goethe exam preparation.

--- a/scripts/generate_daily_calendar_post.py
+++ b/scripts/generate_daily_calendar_post.py
@@ -441,6 +441,12 @@ DAILY_MESSAGE_VARIATIONS = [
     "Celebrate your consistency—small wins create fluent speakers.",
 ]
 
+BASE_FALOWEN_ANGLE = (
+    "Falowen is a German learning app built by Ghanaians to help students progress faster. "
+    "It combines AI learning tools, a built syllabus, structured assignments, and a progress tracker "
+    "that has helped many students prepare for and pass their Goethe exams."
+)
+
 
 def slugify(text: str) -> str:
     text = text.strip().lower()
@@ -477,6 +483,15 @@ def pick_day_config(day_number: int) -> dict | None:
     return falowen30DayBlogCalendar.get(f"day_{day_number}")
 
 
+def normalize_unsplash_image_url(url: str) -> str:
+    prefix = "https://unsplash.com/s/photos/"
+    if not url.startswith(prefix):
+        return url
+
+    query = url.removeprefix(prefix).strip().replace("-", ",")
+    return f"https://source.unsplash.com/featured/?{query}"
+
+
 def build_body(day_number: int, day_config: dict) -> str:
     variation = DAILY_MESSAGE_VARIATIONS[day_number - 1]
     reading_lines = [
@@ -495,9 +510,9 @@ def build_body(day_number: int, day_config: dict) -> str:
     ]
 
     mini_examples = [
-        f"- **Starter line:** Ich lerne heute etwas über *{day_config['keyword']}*.",
-        "- **Question line:** Kannst du mir ein einfaches Beispiel geben?",
-        "- **Confidence line:** Jeden Tag mache ich kleine Fortschritte auf Deutsch.",
+        "- Learning German now helps students build confidence before they arrive in Germany.",
+        "- German study also introduces students to new cultures and international communication.",
+        "- Strong German preparation can support students working toward visa and relocation requirements.",
     ]
 
     sections = [
@@ -519,12 +534,12 @@ def build_body(day_number: int, day_config: dict) -> str:
         *mini_examples,
         "",
         "## Falowen angle",
-        day_config["promotion_angle"],
+        BASE_FALOWEN_ANGLE,
         "",
         "## Quick practice task",
         (
-            f"Write 4-6 short German lines around **{day_config['keyword']}** and say them out loud twice. "
-            "If possible, send them to your tutor for feedback."
+            "Are you ready to start your German journey? Sign up on Falowen today, follow the syllabus step by "
+            "step, and begin building real progress toward your study, travel, and visa goals."
         ),
         "",
         "## 5-minute revision plan",
@@ -545,6 +560,8 @@ def build_post(day_config: dict, body: str, publish_date: date) -> str:
     tags = ["falowen", "german", "30-day-blog", slug]
     tag_string = ", ".join(tags)
 
+    image_url = normalize_unsplash_image_url(day_config["unsplash_link"])
+
     front_matter = [
         "---",
         "layout: post",
@@ -553,7 +570,7 @@ def build_post(day_config: dict, body: str, publish_date: date) -> str:
         f"tags: [{tag_string}]",
         f"categories: [{day_config['category']}]",
         f'excerpt: "{day_config["excerpt"]}"',
-        f"image: {day_config['unsplash_link']}",
+        f"image: {image_url}",
         f'image_alt: "{day_config["title"]}"',
         f"permalink: /{slug}/",
         "seo:",


### PR DESCRIPTION
### Motivation
- Allow authors to use Unsplash search page links in front matter and automatically resolve them to a stable `source.unsplash.com` featured image URL for templates and schema.org JSON-LD.
- Centralize image normalization so generated posts use the same resolved image format as manually authored posts.
- Refresh generated 30-day blog content to include a consistent Falowen marketing angle and updated mini-examples and CTAs.

### Description
- Updated `_layouts/post.html` to assign `post_image`, detect Unsplash search links, convert them to `https://source.unsplash.com/featured/?...`, and use `post_image` for the `<img src>` and schema.org `image` field.
- Added `normalize_unsplash_image_url` helper in `scripts/generate_daily_calendar_post.py`, used it in `build_post` to write normalized `image` front matter, and introduced `BASE_FALOWEN_ANGLE` as the canonical promotion text.
- Modified the daily post generator's `build_body` to replace the previous mini-examples, swap the per-post promotion with `BASE_FALOWEN_ANGLE`, and change the quick practice task into a Falowen signup CTA.
- Updated the example post `_posts/2026-04-15-why-learning-german-in-ghana-is-a-smart-move.md` to use the normalized `source.unsplash.com` image URL and applied the content/CTA edits produced by the generator changes.

### Testing
- No automated tests were added or executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df73e3e4508322b71c1bb55706b872)