### PR TITLE
Treat masked/placeholder secrets as missing in social publisher

### DIFF
--- a/scripts/post_to_social.py
+++ b/scripts/post_to_social.py
@@ -14,7 +14,15 @@ def env_value(*names: str) -> str | None:
         if raw is None:
             continue
         value = raw.strip()
-        if value and value != "***":
+        if not value:
+            continue
+        # GitHub Actions commonly masks missing/misconfigured secrets as "***".
+        # Treat any all-asterisk value as absent to avoid invalid auth headers.
+        if set(value) == {"*"}:
+            continue
+        if value.startswith("${{") and value.endswith("}}"):
+            continue
+        if value:
             return value
     return None
 


### PR DESCRIPTION
### Motivation
- Prevent passing masked or unresolved secret placeholders into HTTP headers which caused `ValueError: Invalid header value b'***'` when publishing to social APIs.

### Description
- Harden `env_value` in `scripts/post_to_social.py` to treat empty values as missing.
- Ignore all-asterisk values (e.g. `***`) and unresolved GitHub Actions expression placeholders (`${{ ... }}`) so they are not returned as credentials.
- Keep existing behavior of returning the first valid environment value when present.

### Testing
- Ran `python -m py_compile scripts/post_to_social.py` which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df7b5583b08322a6f322d022bc2993)