### PR TITLE
feat(blog): generate topic-matched daily posts with OpenAI + stable images

### DIFF
--- a/.github/workflows/weekly_blog.yml
+++ b/.github/workflows/weekly_blog.yml
@@ -28,6 +28,9 @@ jobs:
           python-version: "3.11"
 
       - name: Generate today's calendar post
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          OPENAI_MODEL: ${{ vars.OPENAI_MODEL }}
         run: |
           python scripts/generate_daily_calendar_post.py --start-date 2026-04-15
 

--- a/_posts/2026-04-16-german-alphabet-for-complete-beginners.md
+++ b/_posts/2026-04-16-german-alphabet-for-complete-beginners.md
@@ -5,22 +5,76 @@ date: 2026-04-16
 tags: [falowen, german, 30-day-blog, german-alphabet-for-complete-beginners]
 categories: [Beginner German]
 excerpt: "Learn the German alphabet in a simple way and build a strong foundation for speaking and reading."
-image: https://source.unsplash.com/featured/?alphabet,letters
+image: https://raw.githubusercontent.com/learngermanghana/falowen-blog/main/photos/pexels-joshuamckn-1139317.jpg
 image_alt: "German Alphabet for Complete Beginners"
 permalink: /german-alphabet-for-complete-beginners/
 seo:
   title: "German Alphabet for Beginners | Falowen"
   description: "Master the German alphabet with easy beginner lessons. Start learning German step by step with Falowen."
 ---
-**Intro:** Learn the German alphabet in a simple way and build a strong foundation for speaking and reading.
+## German alphabet overview (A–Z)
 
-**Rule:** For this grammar topic on **German alphabet for beginners**, keep your sentence pattern simple: use one clear structure first, then add detail with time or place expressions.
+German uses the same 26 letters as English, plus four extra characters: **ä, ö, ü, ß**.
 
-**Examples:**
-- *Ich lerne Deutsch.*
-- *Heute lerne ich Deutsch.*
-- *Lernst du heute?*
+- **A B C D E F G H I J K L M**
+- **N O P Q R S T U V W X Y Z**
+- Extra: **Ä Ö Ü ß**
 
-**Common mistake:** Mixing statement and question word order in one sentence, or placing the main verb too late.
+---
 
-**Practice line:** Day 2/30 — write 3 short sentences using this grammar rule and read them aloud.
+## How key letters are pronounced
+
+Here are beginner-friendly sound hints:
+
+- **V** is often pronounced like **f** → *Vater* (father)
+- **W** is pronounced like English **v** → *Wasser* (water)
+- **J** sounds like English **y** → *ja* (yes)
+- **Z** sounds like **ts** → *Zeit* (time)
+- **ß** sounds like **ss** → *Straße* (street)
+
+---
+
+## Umlauts made simple: ä, ö, ü
+
+Umlauts change the base vowel sound:
+
+- **a → ä** (*Mann* → *Männer*)
+- **o → ö** (*schon* vs *schön*)
+- **u → ü** (*mussen* is wrong spelling; *müssen* is correct)
+
+Practice by saying pairs aloud and listening for the vowel shift.
+
+---
+
+## Starter words for each special letter
+
+- **Ä**: *Äpfel* (apples)
+- **Ö**: *Öl* (oil)
+- **Ü**: *über* (over/about)
+- **ß**: *groß* (big)
+
+Use each word in a short sentence:
+
+- *Die Äpfel sind frisch.*
+- *Das Öl ist teuer.*
+- *Das Buch liegt über dem Tisch.*
+- *Das Haus ist groß.*
+
+---
+
+## Common beginner mistakes
+
+- Confusing **w** and **v** pronunciation.
+- Ignoring umlauts in spelling and speech.
+- Replacing **ß** randomly with **b** or skipping it.
+
+---
+
+## Quick daily practice (5 minutes)
+
+1. Read A–Z once slowly.
+2. Read **ä, ö, ü, ß** five times each.
+3. Say 6 words aloud: *Vater, Wasser, ja, Zeit, Straße, über*.
+4. Write 3 short sentences using today’s words.
+
+Start your beginner German journey today with Falowen and our guided classes.

--- a/scripts/generate_daily_calendar_post.py
+++ b/scripts/generate_daily_calendar_post.py
@@ -2,11 +2,27 @@ from __future__ import annotations
 
 import argparse
 from datetime import date, datetime, timezone
+import json
+import os
 from pathlib import Path
 import re
+from urllib import error, request
 
 POSTS_DIR = Path("_posts")
 DEFAULT_START_DATE = date(2026, 4, 15)
+OPENAI_API_URL = "https://api.openai.com/v1/chat/completions"
+DEFAULT_OPENAI_MODEL = "gpt-4.1-mini"
+
+REPO_IMAGE_POOL = [
+    "https://raw.githubusercontent.com/learngermanghana/falowen-blog/main/photos/pexels-polina-kovaleva-8362564.jpg",
+    "https://raw.githubusercontent.com/learngermanghana/falowen-blog/main/photos/pexels-joshuamckn-1139317.jpg",
+    "https://raw.githubusercontent.com/learngermanghana/falowen-blog/main/photos/pexels-rdne-8499492.jpg",
+    "https://raw.githubusercontent.com/learngermanghana/falowen-blog/main/photos/pexels-prince-beguin-81839921-10334158.jpg",
+    "https://raw.githubusercontent.com/learngermanghana/falowen-blog/main/photos/pexels-artempodrez-5726810.jpg",
+    "https://raw.githubusercontent.com/learngermanghana/falowen-blog/main/photos/pexels-ulfet-680828476-31703180.jpg",
+    "https://raw.githubusercontent.com/learngermanghana/falowen-blog/main/photos/pexels-saeed-chembea-1063286943-32719717.jpg",
+    "https://raw.githubusercontent.com/learngermanghana/falowen-blog/main/photos/pexels-eden-34297765.jpg",
+]
 
 GERMAN_CHAR_MAP = {
     "ä": "ae",
@@ -519,13 +535,82 @@ def pick_day_config(day_number: int) -> dict | None:
     return {**day_config, "content_type": CONTENT_TYPE_BY_DAY.get(day_number, "promo_essay")}
 
 
-def normalize_unsplash_image_url(url: str) -> str:
+def resolve_image_url(day_number: int, day_config: dict) -> str:
+    explicit_image_url = day_config.get("image_url")
+    if explicit_image_url:
+        return explicit_image_url
+
+    url = day_config["unsplash_link"]
     prefix = "https://unsplash.com/s/photos/"
     if not url.startswith(prefix):
         return url
 
-    query = url.removeprefix(prefix).strip().replace("-", ",")
-    return f"https://source.unsplash.com/featured/?{query}"
+    return REPO_IMAGE_POOL[(day_number - 1) % len(REPO_IMAGE_POOL)]
+
+
+def generate_ai_body(day_number: int, day_config: dict) -> str | None:
+    api_key = os.getenv("OPENAI_API_KEY", "").strip()
+    if not api_key or api_key == "***":
+        return None
+
+    model = os.getenv("OPENAI_MODEL", DEFAULT_OPENAI_MODEL).strip() or DEFAULT_OPENAI_MODEL
+    content_type = day_config.get("content_type", "promo_essay")
+    prompt = (
+        "Write a Jekyll blog post body in markdown only (no front matter).\n"
+        f"Day: {day_number}/30\n"
+        f"Title: {day_config['title']}\n"
+        f"Keyword: {day_config['keyword']}\n"
+        f"Focus: {day_config['focus']}\n"
+        f"Category: {day_config['category']}\n"
+        f"Content type: {content_type}\n"
+        f"CTA to include exactly once near the end: {day_config['cta']}\n"
+        "Requirements:\n"
+        "- Match the topic tightly; include at least 6 topic-specific examples.\n"
+        "- Use H2/H3 headings and bullet points for readability.\n"
+        "- Keep beginner-friendly tone and practical learner advice.\n"
+        "- Avoid generic filler text.\n"
+        "- Do not mention AI or model instructions.\n"
+    )
+
+    payload = {
+        "model": model,
+        "messages": [
+            {
+                "role": "system",
+                "content": (
+                    "You are a German-learning curriculum writer for Falowen. "
+                    "Produce clear, practical markdown lesson content."
+                ),
+            },
+            {"role": "user", "content": prompt},
+        ],
+        "temperature": 0.6,
+    }
+    req = request.Request(
+        OPENAI_API_URL,
+        data=json.dumps(payload).encode("utf-8"),
+        headers={
+            "Authorization": f"Bearer {api_key}",
+            "Content-Type": "application/json",
+        },
+        method="POST",
+    )
+    try:
+        with request.urlopen(req, timeout=45) as resp:
+            data = json.loads(resp.read().decode("utf-8"))
+    except (error.URLError, error.HTTPError, TimeoutError, json.JSONDecodeError) as exc:
+        print(f"OpenAI generation failed, using template fallback: {exc}")
+        return None
+
+    ai_body = (
+        data.get("choices", [{}])[0]
+        .get("message", {})
+        .get("content", "")
+        .strip()
+    )
+    if not ai_body:
+        return None
+    return ai_body + "\n"
 
 
 def _build_promo_essay(day_number: int, day_config: dict) -> str:
@@ -659,12 +744,12 @@ def build_body(day_number: int, day_config: dict) -> str:
     return _build_promo_essay(day_number, day_config)
 
 
-def build_post(day_config: dict, body: str, publish_date: date) -> str:
+def build_post(day_number: int, day_config: dict, body: str, publish_date: date) -> str:
     slug = day_config.get("slug") or slugify(day_config["title"])
     tags = ["falowen", "german", "30-day-blog", slug]
     tag_string = ", ".join(tags)
 
-    image_url = normalize_unsplash_image_url(day_config["unsplash_link"])
+    image_url = resolve_image_url(day_number, day_config)
 
     front_matter = [
         "---",
@@ -713,8 +798,8 @@ def main() -> int:
         print(f"Post already exists: {post_path}")
         return 0
 
-    body = build_body(day_number, day_config)
-    post_md = build_post(day_config, body, run_date)
+    body = generate_ai_body(day_number, day_config) or build_body(day_number, day_config)
+    post_md = build_post(day_number, day_config, body, run_date)
     post_path.write_text(post_md, encoding="utf-8")
     print(f"Created day {day_number}: {post_path}")
     return 0

--- a/tests/test_generate_daily_calendar_post.py
+++ b/tests/test_generate_daily_calendar_post.py
@@ -5,6 +5,7 @@ from scripts.generate_daily_calendar_post import (
     build_body,
     compute_day_number,
     pick_day_config,
+    resolve_image_url,
 )
 
 
@@ -40,6 +41,12 @@ class DailyCalendarPostTests(unittest.TestCase):
         self.assertIn("1. **Start small and consistent**", body_21)
         self.assertIn("Day 21/30 CTA:", body_21)
         self.assertNotEqual(body_1, body_2)
+
+    def test_resolve_image_url_falls_back_to_repo_image_for_unsplash_search_pages(self) -> None:
+        day_2 = pick_day_config(2)
+        assert day_2 is not None
+        image_url = resolve_image_url(2, day_2)
+        self.assertIn("raw.githubusercontent.com/learngermanghana/falowen-blog/main/photos/", image_url)
 
 
 if __name__ == "__main__":

--- a/workflows/daily-calendar-post.yml
+++ b/workflows/daily-calendar-post.yml
@@ -52,6 +52,9 @@ jobs:
           echo "start_date=$INPUT_START_DATE" >> "$GITHUB_OUTPUT"
 
       - name: Generate daily calendar post
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          OPENAI_MODEL: ${{ vars.OPENAI_MODEL }}
         run: |
           args=(--date "${{ steps.date.outputs.run_date }}")
           if [ -n "${{ steps.date.outputs.start_date }}" ]; then


### PR DESCRIPTION
### Motivation
- Improve relevance and reliability of daily calendar posts by producing topic-matched lesson bodies and using stable image URLs instead of fragile Unsplash search-page conversions.

### Description
- Add optional OpenAI body generation to `scripts/generate_daily_calendar_post.py` driven by `OPENAI_API_KEY` and optional `OPENAI_MODEL`, with a safe template fallback when the key is missing or generation fails.
- Replace Unsplash search-page normalization with a rotating pool of repo-hosted raw GitHub image URLs and add `resolve_image_url` to prefer explicit `image_url` when present.
- Wire `OPENAI_API_KEY` and `OPENAI_MODEL` into the daily generation workflows (`.github/workflows/weekly_blog.yml` and `workflows/daily-calendar-post.yml`).
- Update the existing `_posts/2026-04-16-german-alphabet-for-complete-beginners.md` to use a stable image URL and topic-aligned content, and add a test that verifies the image fallback behavior in `tests/test_generate_daily_calendar_post.py`.

### Testing
- Ran unit tests: `python -m unittest tests/test_generate_daily_calendar_post.py tests/test_generate_post.py`, all tests passed (9 tests, OK).
- Performed a dry-run: `python scripts/generate_daily_calendar_post.py --date 2026-04-16 --start-date 2026-04-15 --dry-run`, which reported the expected title and target file path.
- The repository lint/build checks were not modified beyond the included tests and dry-run validation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e1052cbdb88322abcc86aa6b5dc99d)