### PR TITLE
Use local glittering Falowen “F” SVG favicon

### DIFF
--- a/_includes/head-custom.html
+++ b/_includes/head-custom.html
@@ -8,7 +8,7 @@
 <meta name="robots" content="{{ page.robots }}">
 {% endif %}
 
-<link rel="icon" href="https://i.imgur.com/mcrrGfd.png" />
+<link rel="icon" type="image/svg+xml" href="{{ '/assets/img/favicon-glitter-f.svg' | relative_url }}" />
 
 <link
   rel="feed"

--- a/assets/img/favicon-glitter-f.svg
+++ b/assets/img/favicon-glitter-f.svg
@@ -1,0 +1,33 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="Glittering Falowen F favicon">
+  <defs>
+    <radialGradient id="bg" cx="30%" cy="25%" r="80%">
+      <stop offset="0%" stop-color="#2e1347"/>
+      <stop offset="100%" stop-color="#12071f"/>
+    </radialGradient>
+    <linearGradient id="gold" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#fff7bf"/>
+      <stop offset="45%" stop-color="#f8d96f"/>
+      <stop offset="100%" stop-color="#d39b1c"/>
+    </linearGradient>
+    <filter id="glow" x="-30%" y="-30%" width="160%" height="160%">
+      <feGaussianBlur stdDeviation="1.2" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+  </defs>
+
+  <rect x="2" y="2" width="60" height="60" rx="14" fill="url(#bg)"/>
+
+  <g fill="url(#gold)" filter="url(#glow)">
+    <path d="M22 14h22v7H30v9h12v7H30v13h-8z"/>
+  </g>
+
+  <g fill="#fff6cf" opacity="0.95">
+    <path d="M48 12l1.6 4.4L54 18l-4.4 1.6L48 24l-1.6-4.4L42 18l4.4-1.6z"/>
+    <path d="M15 43l1.1 2.9L19 47l-2.9 1.1L15 51l-1.1-2.9L11 47l2.9-1.1z"/>
+    <circle cx="44" cy="46" r="1.3"/>
+    <circle cx="18" cy="18" r="1.1"/>
+  </g>
+</svg>


### PR DESCRIPTION
### Motivation
- Replace the externally-hosted favicon with a local, branded SVG that visually represents Falowen (golden “F” with glitter) and removes reliance on a third-party image host.

### Description
- Added a new SVG favicon at `assets/img/favicon-glitter-f.svg` that includes a dark radial background, a gold-gradient stylized “F”, glow filter, and small sparkle accents.
- Updated the shared head include ` _includes/head-custom.html` to reference the new favicon using `type="image/svg+xml"` and `{{ '/assets/img/favicon-glitter-f.svg' | relative_url }}` instead of the previous external PNG URL.
- No other site logic or content files were modified.

### Testing
- Ran `bundle exec jekyll build` in the environment, which failed because the `jekyll` executable is not installed (bundler reported: `command not found: jekyll`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e10f839ba883229014af8694b76fb5)