### PR TITLE
Prefer front-matter `permalink` when building post URLs for social shares

### DIFF
--- a/scripts/post_to_social.py
+++ b/scripts/post_to_social.py
@@ -52,7 +52,13 @@ def slug_from_filename(path: Path) -> str:
     return re.sub(r"^\d{4}-\d{2}-\d{2}-", "", name)
 
 
-def post_url(site_url: str, post_path: Path) -> str:
+def post_url(site_url: str, post_path: Path, front_matter: dict[str, str] | None = None) -> str:
+    if front_matter:
+        permalink = front_matter.get("permalink", "").strip()
+        if permalink:
+            normalized = permalink if permalink.startswith("/") else f"/{permalink}"
+            return f"{site_url.rstrip('/')}{normalized}"
+
     return f"{site_url.rstrip('/')}/{slug_from_filename(post_path)}/"
 
 
@@ -187,7 +193,7 @@ def main() -> int:
     excerpt = fm.get("excerpt") or excerpt_from_body(body)
     image_url = fm.get("image")
 
-    url = post_url(args.site_url, post_path)
+    url = post_url(args.site_url, post_path, fm)
 
     publish_linkedin(f"{title}\n\n{excerpt}", url, args.dry_run)
     publish_instagram(f"{title}\n\n{excerpt}", url, image_url, args.dry_run)

--- a/tests/test_post_to_social.py
+++ b/tests/test_post_to_social.py
@@ -3,7 +3,9 @@ import unittest
 from contextlib import redirect_stdout
 from unittest.mock import patch
 
-from scripts.post_to_social import publish_linkedin
+from pathlib import Path
+
+from scripts.post_to_social import post_url, publish_linkedin
 
 
 class PublishLinkedInTests(unittest.TestCase):
@@ -21,6 +23,25 @@ class PublishLinkedInTests(unittest.TestCase):
             publish_linkedin("Hello world", "https://example.com/post", dry_run=True)
 
         self.assertIn("[linkedin] Dry run: would publish post", output.getvalue())
+
+
+class PostUrlTests(unittest.TestCase):
+    def test_post_url_uses_front_matter_permalink_when_available(self) -> None:
+        url = post_url(
+            "https://falowen.com/",
+            Path("_posts/2026-04-16-german-alphabet-for-complete-beginners.md"),
+            {"permalink": "/german-alphabet-for-complete-beginners/"},
+        )
+
+        self.assertEqual("https://falowen.com/german-alphabet-for-complete-beginners/", url)
+
+    def test_post_url_falls_back_to_slug_from_filename(self) -> None:
+        url = post_url(
+            "https://falowen.com",
+            Path("_posts/2026-04-16-german-alphabet-for-complete-beginners.md"),
+        )
+
+        self.assertEqual("https://falowen.com/german-alphabet-for-complete-beginners/", url)
 
     @patch.dict(
         "os.environ",


### PR DESCRIPTION
### Motivation
- LinkedIn and other social shares were sometimes using an incomplete URL derived from the filename slug instead of the site's canonical `permalink` defined in a post's front matter.

### Description
- Updated `post_url` in `scripts/post_to_social.py` to accept an optional `front_matter` dict and prefer the front-matter `permalink` when present, normalizing leading slashes.
- Preserved the existing fallback to a filename-derived slug when no `permalink` is defined.
- Wired `main()` to pass the parsed front matter (`fm`) into `post_url` so publishing functions receive the correct canonical URL.
- Added `PostUrlTests` to `tests/test_post_to_social.py` with tests for permalink usage and slug fallback, and adjusted imports accordingly.

### Testing
- Ran `python -m unittest tests/test_post_to_social.py` and all tests passed (`Ran 4 tests — OK`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e10b1a66d08321bc836643c24ab537)