### PR TITLE
Fix social publish workflow post detection across push range

### DIFF
--- a/workflows/social-publish.yml
+++ b/workflows/social-publish.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          fetch-depth: 2
+          fetch-depth: 0
 
       - name: Setup Python
         uses: actions/setup-python@v5
@@ -42,7 +42,14 @@ jobs:
           if [ -n "${{ github.event.inputs.post_path }}" ]; then
             target="${{ github.event.inputs.post_path }}"
           else
-            target=$(git diff --name-only HEAD~1 HEAD | awk '/^_posts\/.*\.md$/ {print; exit}')
+            before="${{ github.event.before }}"
+            if [ -z "$before" ] || [ "$before" = "0000000000000000000000000000000000000000" ]; then
+              before="HEAD~1"
+            fi
+
+            # Inspect the full push range so we don't miss post changes that
+            # happened earlier in a multi-commit push.
+            target=$(git diff --name-only "$before" "${{ github.sha }}" -- '_posts/*.md' | head -n 1)
           fi
 
           if [ -z "$target" ]; then


### PR DESCRIPTION
### Motivation
- The workflow sometimes skipped publishing social posts (e.g., LinkedIn) when a post change occurred earlier in a multi-commit push because it only inspected the most recent commit range. 
- The checkout depth was shallow which could make range diffs unavailable in CI. 

### Description
- Update `workflows/social-publish.yml` to diff the full push range using `github.event.before` -> `github.sha` and fall back to `HEAD~1` for initial pushes. 
- Change the checkout step to `fetch-depth: 0` so the workflow always has full history for the range diff. 
- Preserve the `workflow_dispatch` `post_path` override behavior so manual runs can still target a specific post file.

### Testing
- Ran `python -m unittest tests/test_post_to_social.py` and all tests passed (`OK`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e28b145a088322928c556d33bcd1d1)