### PR TITLE
fix: trigger LinkedIn auto-posting for daily blog commits

### DIFF
--- a/.github/workflows/weekly_blog.yml
+++ b/.github/workflows/weekly_blog.yml
@@ -46,5 +46,5 @@ jobs:
           git config user.email "falowen-bot@users.noreply.github.com"
 
           git add _posts
-          git commit -m "chore(blog): daily calendar post [skip ci]"
+          git commit -m "chore(blog): daily calendar post"
           git push


### PR DESCRIPTION
### Motivation
- The daily post generator committed with `"[skip ci]"` in its message which prevented push-triggered workflows (including the LinkedIn/social publish workflow) from running, so auto-posts were not happening after daily updates.

### Description
- Remove `"[skip ci]"` from the commit message in `.github/workflows/weekly_blog.yml` so pushes created by the daily generator will trigger other push-based workflows.

### Testing
- No automated test suite was executed for this change; the change was validated by inspecting the workflow diff and creating a local commit that updated only the commit message.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e731be179c83228a5ac6e6b7a0e26e)