### PR TITLE
Add LinkedIn publishing verification test

### DIFF
--- a/tests/test_post_to_social.py
+++ b/tests/test_post_to_social.py
@@ -24,6 +24,41 @@ class PublishLinkedInTests(unittest.TestCase):
 
         self.assertIn("[linkedin] Dry run: would publish post", output.getvalue())
 
+    @patch.dict(
+        "os.environ",
+        {
+            "LINKEDIN_ACCESS_TOKEN": "token",
+            "LINKEDIN_AUTHOR_URN": "urn:li:person:author",
+        },
+        clear=True,
+    )
+    @patch("scripts.post_to_social.post_json")
+    def test_publish_linkedin_sends_publish_request(self, mock_post_json) -> None:
+        mock_post_json.return_value = (201, '{"id":"123"}')
+
+        publish_linkedin("New post", "https://example.com/post", dry_run=False)
+
+        mock_post_json.assert_called_once_with(
+            "https://api.linkedin.com/v2/ugcPosts",
+            {
+                "author": "urn:li:person:author",
+                "lifecycleState": "PUBLISHED",
+                "specificContent": {
+                    "com.linkedin.ugc.ShareContent": {
+                        "shareCommentary": {
+                            "text": "New post\n\nRead more: https://example.com/post"
+                        },
+                        "shareMediaCategory": "NONE",
+                    }
+                },
+                "visibility": {"com.linkedin.ugc.MemberNetworkVisibility": "PUBLIC"},
+            },
+            {
+                "Authorization": "Bearer token",
+                "X-Restli-Protocol-Version": "2.0.0",
+            },
+        )
+
 
 class PostUrlTests(unittest.TestCase):
     def test_post_url_uses_front_matter_permalink_when_available(self) -> None:


### PR DESCRIPTION
### Motivation

- Ensure the real LinkedIn publish path is exercised when credentials are present so blog posts actually attempt to share to LinkedIn instead of only checking dry-run behavior. 
- Prevent regressions by verifying the outgoing API request shape and headers used for LinkedIn UGC posts.

### Description

- Add `test_publish_linkedin_sends_publish_request` to `tests/test_post_to_social.py` which patches environment variables and `post_json` to simulate a real publish. 
- The test calls `publish_linkedin` with `dry_run=False` and asserts `post_json` was invoked once with the LinkedIn UGC endpoint, the exact payload structure, and the expected authorization headers. 
- Existing LinkedIn and `post_url` tests are kept intact.

### Testing

- Ran `python -m unittest tests/test_post_to_social.py` which completed successfully (`Ran 5 tests ... OK`).
- The test run simulated a publish and observed a `201` response from the patched `post_json` call as expected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef4c0d03a48321a92ad60a4d21c51a)