### PR TITLE
fix(ci): run LinkedIn auto-publish from daily workflow completion

### DIFF
--- a/.github/workflows/linkedin-blog-publish.yml
+++ b/.github/workflows/linkedin-blog-publish.yml
@@ -1,10 +1,9 @@
 name: Auto Post Blog Updates to LinkedIn
 
 on:
-  push:
-    branches: [main]
-    paths:
-      - "_posts/*.md"
+  workflow_run:
+    workflows: ["30-Day Daily Blog Auto-Publish"]
+    types: [completed]
   workflow_dispatch:
     inputs:
       post_path:
@@ -22,6 +21,10 @@ permissions:
 
 jobs:
   linkedin_publish:
+    if: >
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'workflow_run' &&
+       github.event.workflow_run.conclusion == 'success')
     runs-on: ubuntu-latest
 
     steps:
@@ -42,18 +45,11 @@ jobs:
           if [ -n "${{ github.event.inputs.post_path }}" ]; then
             target="${{ github.event.inputs.post_path }}"
           else
-            before="${{ github.event.before }}"
-            if [ -z "$before" ] || [ "$before" = "0000000000000000000000000000000000000000" ]; then
-              before="HEAD~1"
-            fi
-
-            # Inspect the full push range so we don't miss post changes that
-            # happened earlier in a multi-commit push.
-            target=$(git diff --name-only "$before" "${{ github.sha }}" -- '_posts/*.md' | head -n 1)
+            target=$(git ls-files -- "_posts/*.md" | sort | tail -n 1)
           fi
 
           if [ -z "$target" ]; then
-            echo "No changed post detected. Skipping publish."
+            echo "No post file detected. Skipping publish."
             echo "skip=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi


### PR DESCRIPTION
### Motivation
- Pushes performed by workflows using `GITHUB_TOKEN` do not trigger downstream `push`-based workflows, so the LinkedIn publish job never ran after the daily post generator committed a new `_posts/*.md` file.

### Description
- Replace the `push` trigger with a `workflow_run` trigger that listens for completion of `30-Day Daily Blog Auto-Publish` and keep `workflow_dispatch` for manual runs.
- Add a job-level guard `if: github.event_name == 'workflow_dispatch' || (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success')` so the LinkedIn job only executes for successful upstream runs or manual dispatch.
- Update post resolution logic to choose the newest `_posts/*.md` via `git ls-files -- "_posts/*.md" | sort | tail -n 1` when `post_path` is not provided, since push diff metadata is not available on `workflow_run` events.

### Testing
- No automated tests were executed for this workflow-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f333838ab883219d9eabb956232eee)