### PR TITLE
Hardcode SITE_URL for LinkedIn publish workflow

### DIFF
--- a/.github/workflows/linkedin-blog-publish.yml
+++ b/.github/workflows/linkedin-blog-publish.yml
@@ -64,7 +64,7 @@ jobs:
           # These values are expected to be configured as GitHub Actions repository secrets.
           LINKEDIN_ACCESS_TOKEN: ${{ secrets.LINKEDIN_ACCESS_TOKEN }}
           LINKEDIN_AUTHOR_URN: ${{ secrets.LINKEDIN_AUTHOR_URN }}
-          SITE_URL: ${{ vars.SITE_URL }}
+          SITE_URL: https://blog.falowen.app
         run: |
           DRY=""
           if [ "${{ github.event.inputs.dry_run }}" = "true" ]; then


### PR DESCRIPTION
### Motivation
- Ensure LinkedIn posts always use the correct public blog domain instead of depending on repository-level variables that may be unset or differ between environments.

### Description
- Replaced the `SITE_URL` environment value in the `Publish to LinkedIn` job of `.github/workflows/linkedin-blog-publish.yml` with the hardcoded URL `https://blog.falowen.app`.

### Testing
- Searched the repository with `rg` to locate the workflow and confirm references to `SITE_URL` were updated successfully.
- Applied the patch and verified the workflow snippet using `nl`/`sed` to confirm the `SITE_URL: https://blog.falowen.app` line is present.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3366d43c48321888bda825f140b43)