### PR TITLE
Refresh post hero images from Unsplash by default (cache-busted)

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -15,7 +15,12 @@ layout: default
     </p>
   </header>
   {% assign post_image = page.image %}
-  {% if post_image and post_image contains "https://unsplash.com/s/photos/" %}
+  {% assign refresh_hero_images = page.refresh_hero_images | default: true %}
+  {% if refresh_hero_images %}
+    {% assign unsplash_query = page.hero_query | default: page.title | slugify | replace: "-", "," %}
+    {% assign refresh_sig = site.time | date: "%s" %}
+    {% assign post_image = "https://source.unsplash.com/featured/?" | append: unsplash_query | append: "&sig=" | append: refresh_sig %}
+  {% elsif post_image and post_image contains "https://unsplash.com/s/photos/" %}
     {% assign unsplash_query = post_image | remove: "https://unsplash.com/s/photos/" | replace: "-", "," %}
     {% assign post_image = "https://source.unsplash.com/featured/?" | append: unsplash_query %}
   {% endif %}


### PR DESCRIPTION
### Motivation
- Blog posts were repeatedly showing stale or old hero images instead of pulling fresh visuals on rebuilds.  
- The goal is to fetch a new Unsplash hero image for posts automatically while still allowing per-post opt-out.  
- Allowing an override query lets authors control the search term when needed.

### Description
- Updated `_layouts/post.html` to introduce a `refresh_hero_images` front-matter toggle that defaults to `true` and controls automatic hero refreshing.  
- When enabled, the layout builds an Unsplash URL using a `hero_query` (falling back to a slugified `page.title`) and appends a cache-busting `&sig=` parameter derived from `site.time` so rebuilt pages request fresh images.  
- Preserved existing behavior for posts that explicitly provide an `unsplash.com/s/photos/...` URL when `refresh_hero_images` is disabled.

### Testing
- No automated test suite was executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff0bb67d8083219cc98ca7ca2e9415)