### PR TITLE
Extend calendar to 6 months and append standard closing to generated posts

### DIFF
--- a/scripts/generate_daily_calendar_post.py
+++ b/scripts/generate_daily_calendar_post.py
@@ -508,7 +508,7 @@ def slugify(text: str) -> str:
 
 
 def parse_args() -> argparse.Namespace:
-    parser = argparse.ArgumentParser(description="Generate one daily blog post from a fixed 30-day calendar.")
+    parser = argparse.ArgumentParser(description="Generate one daily blog post from a fixed 6-month calendar.")
     parser.add_argument("--date", help="Publishing date in YYYY-MM-DD format (default: current UTC date).")
     parser.add_argument("--start-date", help="Start date for day_1 in YYYY-MM-DD format (default: 2026-04-15).")
     parser.add_argument("--force", action="store_true", help="Overwrite existing file if present.")
@@ -527,12 +527,22 @@ def compute_day_number(run_date: date, start_date: date) -> int:
 
 
 def pick_day_config(day_number: int) -> dict | None:
-    if day_number < 1 or day_number > 30:
+    if day_number < 1 or day_number > 180:
         return None
-    day_config = falowen30DayBlogCalendar.get(f"day_{day_number}")
+    template_day = ((day_number - 1) % 30) + 1
+    day_config = falowen30DayBlogCalendar.get(f"day_{template_day}")
     if day_config is None:
         return None
-    return {**day_config, "content_type": CONTENT_TYPE_BY_DAY.get(day_number, "promo_essay")}
+    return {**day_config, "content_type": CONTENT_TYPE_BY_DAY.get(template_day, "promo_essay")}
+
+
+def append_standard_closing(body: str) -> str:
+    closing = (
+        "Are you interested learning german. "
+        "check our available classes here https://www.learngermanghana.com/classes"
+    )
+    body = body.rstrip()
+    return f"{body}\n\n{closing}\n"
 
 
 def resolve_image_url(day_number: int, day_config: dict) -> str:
@@ -557,7 +567,7 @@ def generate_ai_body(day_number: int, day_config: dict) -> str | None:
     content_type = day_config.get("content_type", "promo_essay")
     prompt = (
         "Write a Jekyll blog post body in markdown only (no front matter).\n"
-        f"Day: {day_number}/30\n"
+        f"Day: {day_number}/180\n"
         f"Title: {day_config['title']}\n"
         f"Keyword: {day_config['keyword']}\n"
         f"Focus: {day_config['focus']}\n"
@@ -653,7 +663,7 @@ def _build_grammar_notes(day_number: int, day_config: dict) -> str:
                 "verb too late."
             ),
             "",
-            f"**Practice line:** Day {day_number}/30 — write 3 short sentences using this grammar rule and read them aloud.",
+            f"**Practice line:** Day {day_number}/180 — write 3 short sentences using this grammar rule and read them aloud.",
         ]
     ) + "\n"
 
@@ -674,7 +684,7 @@ def _build_vocabulary_notes(day_number: int, day_config: dict) -> str:
             "- **bitte** — please. *Bitte helfen Sie mir.*",
             "",
             (
-                f"**Practical usage line:** Day {day_number}/30 — pick 5 words from today's **{day_config['keyword']}** "
+                f"**Practical usage line:** Day {day_number}/180 — pick 5 words from today's **{day_config['keyword']}** "
                 "topic and create your own mini dialogue."
             ),
         ]
@@ -725,7 +735,7 @@ def _build_list_post(day_number: int, day_config: dict) -> str:
             "5. **Ask for feedback quickly**  ",
             "   Short feedback loops prevent fossilized mistakes and speed up confidence.",
             "",
-            f"Day {day_number}/30 CTA: {day_config['cta']}",
+            f"Day {day_number}/180 CTA: {day_config['cta']}",
         ]
     ) + "\n"
 
@@ -769,7 +779,8 @@ def build_post(day_number: int, day_config: dict, body: str, publish_date: date)
         "",
     ]
 
-    return "\n".join(front_matter) + body
+    body_with_closing = append_standard_closing(body)
+    return "\n".join(front_matter) + body_with_closing
 
 
 def main() -> int:

--- a/tests/test_generate_daily_calendar_post.py
+++ b/tests/test_generate_daily_calendar_post.py
@@ -14,14 +14,18 @@ class DailyCalendarPostTests(unittest.TestCase):
         self.assertEqual(compute_day_number(date(2026, 4, 15), date(2026, 4, 15)), 1)
         self.assertEqual(compute_day_number(date(2026, 4, 16), date(2026, 4, 15)), 2)
 
-    def test_pick_day_config_only_returns_in_30_day_range(self) -> None:
+    def test_pick_day_config_only_returns_in_180_day_range(self) -> None:
         day_1 = pick_day_config(1)
         self.assertIsNotNone(day_1)
         assert day_1 is not None
         self.assertEqual(day_1["content_type"], "promo_essay")
         self.assertIsNotNone(pick_day_config(30))
         self.assertIsNone(pick_day_config(0))
-        self.assertIsNone(pick_day_config(31))
+        day_31 = pick_day_config(31)
+        self.assertIsNotNone(day_31)
+        assert day_31 is not None
+        self.assertEqual(day_31["slug"], day_1["slug"])
+        self.assertIsNone(pick_day_config(181))
 
     def test_build_body_uses_content_type_specific_template(self) -> None:
         day_1 = pick_day_config(1)
@@ -39,7 +43,7 @@ class DailyCalendarPostTests(unittest.TestCase):
         self.assertIn("**Rule:**", body_2)
         self.assertIn("**Common mistake:**", body_2)
         self.assertIn("1. **Start small and consistent**", body_21)
-        self.assertIn("Day 21/30 CTA:", body_21)
+        self.assertIn("Day 21/180 CTA:", body_21)
         self.assertNotEqual(body_1, body_2)
 
     def test_resolve_image_url_falls_back_to_repo_image_for_unsplash_search_pages(self) -> None:


### PR DESCRIPTION
### Motivation
- Expand the fixed calendar from a 30-day cycle to a 180-day (6-month) cycle so the generator can schedule posts for a longer campaign.  
- Ensure generated content and prompts reflect the new 180-day indexing.  
- Add a standard promotional closing to all generated post bodies to include a classes CTA.

### Description
- Change parser description to reference a 6-month calendar and broaden `pick_day_config` to accept day numbers 1..180.  
- Map any day >30 back to a 30-day template via `template_day = ((day_number - 1) % 30) + 1` and use that template's config while resolving `content_type` with the template index.  
- Update text and prompts that previously referenced `/30` to now reference `/180` (AI prompt lines and practice/CTA lines in templates).  
- Add `append_standard_closing` to inject a promotional closing with class signup link and call it from `build_post` so the closing is appended to every generated body.  
- Update unit tests in `tests/test_generate_daily_calendar_post.py` to reflect the 180-day range and to assert mapping behavior for day 31 and day 181.

### Testing
- Ran the updated unit tests in `tests/test_generate_daily_calendar_post.py` with `python -m unittest` and they passed.  
- Verified the modified template outputs include the updated `/180` references and that day 31 maps to day 1 template values according to the new modulo logic.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff0c89e33c83219a2f5f746b31399d)