### PR TITLE
Extend calendar to 180 days, add level/quiz and standard closing, update AI prompt and add social autopost workflow

### DIFF
--- a/scripts/generate_daily_calendar_post.py
+++ b/scripts/generate_daily_calendar_post.py
@@ -508,7 +508,7 @@ def slugify(text: str) -> str:
 
 
 def parse_args() -> argparse.Namespace:
-    parser = argparse.ArgumentParser(description="Generate one daily blog post from a fixed 30-day calendar.")
+    parser = argparse.ArgumentParser(description="Generate one daily blog post from a fixed 6-month calendar.")
     parser.add_argument("--date", help="Publishing date in YYYY-MM-DD format (default: current UTC date).")
     parser.add_argument("--start-date", help="Start date for day_1 in YYYY-MM-DD format (default: 2026-04-15).")
     parser.add_argument("--force", action="store_true", help="Overwrite existing file if present.")
@@ -527,12 +527,40 @@ def compute_day_number(run_date: date, start_date: date) -> int:
 
 
 def pick_day_config(day_number: int) -> dict | None:
-    if day_number < 1 or day_number > 30:
+    if day_number < 1 or day_number > 180:
         return None
-    day_config = falowen30DayBlogCalendar.get(f"day_{day_number}")
+    template_day = ((day_number - 1) % 30) + 1
+    day_config = falowen30DayBlogCalendar.get(f"day_{template_day}")
     if day_config is None:
         return None
-    return {**day_config, "content_type": CONTENT_TYPE_BY_DAY.get(day_number, "promo_essay")}
+    return {**day_config, "content_type": CONTENT_TYPE_BY_DAY.get(template_day, "promo_essay")}
+
+
+def append_standard_closing(body: str) -> str:
+    closing = (
+        "Are you interested learning german. "
+        "check our available classes here https://www.learngermanghana.com/classes"
+    )
+    body = body.rstrip()
+    return f"{body}\n\n{closing}\n"
+
+
+def append_level_and_quiz(body: str, day_number: int) -> str:
+    level_cycle = ["A1", "A1", "A2", "A2", "B1", "B1"]
+    level = level_cycle[(day_number - 1) % len(level_cycle)]
+    quiz_block = "\n".join(
+        [
+            "## Level",
+            f"- Recommended level: **{level}**",
+            "",
+            "## Quick Test",
+            "1. Write one sentence from today’s topic in German.",
+            "2. Translate that sentence into English.",
+            "3. Add one follow-up sentence using a connector (und/aber/weil).",
+        ]
+    )
+    body = body.rstrip()
+    return f"{body}\n\n{quiz_block}\n"
 
 
 def resolve_image_url(day_number: int, day_config: dict) -> str:
@@ -557,7 +585,7 @@ def generate_ai_body(day_number: int, day_config: dict) -> str | None:
     content_type = day_config.get("content_type", "promo_essay")
     prompt = (
         "Write a Jekyll blog post body in markdown only (no front matter).\n"
-        f"Day: {day_number}/30\n"
+        f"Day: {day_number}/180\n"
         f"Title: {day_config['title']}\n"
         f"Keyword: {day_config['keyword']}\n"
         f"Focus: {day_config['focus']}\n"
@@ -568,6 +596,8 @@ def generate_ai_body(day_number: int, day_config: dict) -> str | None:
         "- Match the topic tightly; include at least 6 topic-specific examples.\n"
         "- Use H2/H3 headings and bullet points for readability.\n"
         "- Keep beginner-friendly tone and practical learner advice.\n"
+        "- Include a `## Level` section with one recommended level from A1/A2/B1.\n"
+        "- Include a `## Quick Test` section with 3 short learner questions.\n"
         "- Avoid generic filler text.\n"
         "- Do not mention AI or model instructions.\n"
     )
@@ -653,7 +683,7 @@ def _build_grammar_notes(day_number: int, day_config: dict) -> str:
                 "verb too late."
             ),
             "",
-            f"**Practice line:** Day {day_number}/30 — write 3 short sentences using this grammar rule and read them aloud.",
+            f"**Practice line:** Day {day_number}/180 — write 3 short sentences using this grammar rule and read them aloud.",
         ]
     ) + "\n"
 
@@ -674,7 +704,7 @@ def _build_vocabulary_notes(day_number: int, day_config: dict) -> str:
             "- **bitte** — please. *Bitte helfen Sie mir.*",
             "",
             (
-                f"**Practical usage line:** Day {day_number}/30 — pick 5 words from today's **{day_config['keyword']}** "
+                f"**Practical usage line:** Day {day_number}/180 — pick 5 words from today's **{day_config['keyword']}** "
                 "topic and create your own mini dialogue."
             ),
         ]
@@ -725,7 +755,7 @@ def _build_list_post(day_number: int, day_config: dict) -> str:
             "5. **Ask for feedback quickly**  ",
             "   Short feedback loops prevent fossilized mistakes and speed up confidence.",
             "",
-            f"Day {day_number}/30 CTA: {day_config['cta']}",
+            f"Day {day_number}/180 CTA: {day_config['cta']}",
         ]
     ) + "\n"
 
@@ -769,7 +799,9 @@ def build_post(day_number: int, day_config: dict, body: str, publish_date: date)
         "",
     ]
 
-    return "\n".join(front_matter) + body
+    body_with_level_and_quiz = append_level_and_quiz(body, day_number)
+    body_with_closing = append_standard_closing(body_with_level_and_quiz)
+    return "\n".join(front_matter) + body_with_closing
 
 
 def main() -> int:

--- a/tests/test_generate_daily_calendar_post.py
+++ b/tests/test_generate_daily_calendar_post.py
@@ -3,6 +3,7 @@ from datetime import date
 
 from scripts.generate_daily_calendar_post import (
     build_body,
+    build_post,
     compute_day_number,
     pick_day_config,
     resolve_image_url,
@@ -14,14 +15,18 @@ class DailyCalendarPostTests(unittest.TestCase):
         self.assertEqual(compute_day_number(date(2026, 4, 15), date(2026, 4, 15)), 1)
         self.assertEqual(compute_day_number(date(2026, 4, 16), date(2026, 4, 15)), 2)
 
-    def test_pick_day_config_only_returns_in_30_day_range(self) -> None:
+    def test_pick_day_config_only_returns_in_180_day_range(self) -> None:
         day_1 = pick_day_config(1)
         self.assertIsNotNone(day_1)
         assert day_1 is not None
         self.assertEqual(day_1["content_type"], "promo_essay")
         self.assertIsNotNone(pick_day_config(30))
         self.assertIsNone(pick_day_config(0))
-        self.assertIsNone(pick_day_config(31))
+        day_31 = pick_day_config(31)
+        self.assertIsNotNone(day_31)
+        assert day_31 is not None
+        self.assertEqual(day_31["slug"], day_1["slug"])
+        self.assertIsNone(pick_day_config(181))
 
     def test_build_body_uses_content_type_specific_template(self) -> None:
         day_1 = pick_day_config(1)
@@ -39,7 +44,7 @@ class DailyCalendarPostTests(unittest.TestCase):
         self.assertIn("**Rule:**", body_2)
         self.assertIn("**Common mistake:**", body_2)
         self.assertIn("1. **Start small and consistent**", body_21)
-        self.assertIn("Day 21/30 CTA:", body_21)
+        self.assertIn("Day 21/180 CTA:", body_21)
         self.assertNotEqual(body_1, body_2)
 
     def test_resolve_image_url_falls_back_to_repo_image_for_unsplash_search_pages(self) -> None:
@@ -47,6 +52,18 @@ class DailyCalendarPostTests(unittest.TestCase):
         assert day_2 is not None
         image_url = resolve_image_url(2, day_2)
         self.assertIn("raw.githubusercontent.com/learngermanghana/falowen-blog/main/photos/", image_url)
+
+    def test_build_post_appends_level_test_and_standard_closing(self) -> None:
+        day_1 = pick_day_config(1)
+        assert day_1 is not None
+        body = build_body(1, day_1)
+        post_md = build_post(1, day_1, body, date(2026, 4, 15))
+        self.assertIn("## Level", post_md)
+        self.assertIn("## Quick Test", post_md)
+        self.assertIn(
+            "Are you interested learning german. check our available classes here https://www.learngermanghana.com/classes",
+            post_md,
+        )
 
 
 if __name__ == "__main__":

--- a/workflows/social-auto-post.yml
+++ b/workflows/social-auto-post.yml
@@ -1,0 +1,52 @@
+name: Auto Post Latest Blog to LinkedIn
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "_posts/*.md"
+
+permissions:
+  contents: read
+
+jobs:
+  post-to-linkedin:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Detect latest changed post
+        id: changed_post
+        shell: bash
+        run: |
+          post_file=$(git diff --name-only HEAD^ HEAD -- '_posts/*.md' | tail -n 1)
+          if [ -z "$post_file" ]; then
+            echo "No changed post detected in last push."
+            echo "post_path=" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "post_path=$post_file" >> "$GITHUB_OUTPUT"
+
+      - name: Publish to LinkedIn (and configured socials)
+        if: steps.changed_post.outputs.post_path != ''
+        env:
+          SITE_URL: ${{ vars.SITE_URL }}
+          LINKEDIN_ACCESS_TOKEN: ${{ secrets.LINKEDIN_ACCESS_TOKEN }}
+          LINKEDIN_AUTHOR_URN: ${{ secrets.LINKEDIN_AUTHOR_URN }}
+          LINKEDIN_PERSON_URN: ${{ secrets.LINKEDIN_PERSON_URN }}
+          INSTAGRAM_ACCESS_TOKEN: ${{ secrets.INSTAGRAM_ACCESS_TOKEN }}
+          INSTAGRAM_ACCOUNT_ID: ${{ secrets.INSTAGRAM_ACCOUNT_ID }}
+          MEDIUM_TOKEN: ${{ secrets.MEDIUM_TOKEN }}
+          MEDIUM_USER_ID: ${{ secrets.MEDIUM_USER_ID }}
+        run: |
+          python scripts/post_to_social.py --post "${{ steps.changed_post.outputs.post_path }}"


### PR DESCRIPTION
### Motivation
- Extend the existing 30-day blog calendar to a 6-month (180-day) schedule while reusing the 30-day template cycle for recurring content slots.
- Add learner scaffolding to every generated post by including a recommended `Level` and a short `Quick Test` to increase practical value for students.
- Append a short standard CTA closing to all posts and provide an automated workflow to publish new posts to socials.

### Description
- Updated argument description in `parse_args` and expanded the valid day range in `pick_day_config` from 30 to 180 while mapping `day_number` to a `template_day` via `((day_number - 1) % 30) + 1` to reuse the 30-day templates.
- Changed content strings and templates to reference `/180` instead of `/30` where appropriate and updated `CONTENT_TYPE_BY_DAY` usage to index by the `template_day`.
- Added `append_level_and_quiz` and `append_standard_closing` helper functions and integrated them into `build_post` so generated posts include a `## Level`, `## Quick Test` block and the standard CTA closing.
- Updated `generate_ai_body` prompt to mention `Day: {day_number}/180` and to require a `## Level` and `## Quick Test` in AI-generated content.
- Added a new GitHub Actions workflow `workflows/social-auto-post.yml` to detect the latest changed post in `_posts/*.md` and trigger a social publish step using `scripts/post_to_social.py`.

### Testing
- Ran unit tests with `python -m unittest tests/test_generate_daily_calendar_post.py` and all tests in that file passed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff0c89e33c83219a2f5f746b31399d)