### PR TITLE
Resolve Unsplash search URLs to source.unsplash and update post image/tests

### DIFF
--- a/_posts/2026-05-10-how-falowen-supports-your-german-learning-journey.md
+++ b/_posts/2026-05-10-how-falowen-supports-your-german-learning-journey.md
@@ -5,7 +5,7 @@ date: 2026-05-10
 tags: [falowen, german, 30-day-blog, how-falowen-supports-your-german-learning-journey]
 categories: [Falowen]
 excerpt: "See how Falowen supports your progress with lessons, practice tools, and flexible learning."
-image: https://raw.githubusercontent.com/learngermanghana/falowen-blog/main/photos/pexels-joshuamckn-1139317.jpg
+image: https://images.unsplash.com/photo-1516321165247-4aa89a48be28?auto=format&fit=crop&w=1600&q=80
 image_alt: "How Falowen Supports Your German Learning Journey"
 permalink: /how-falowen-supports-your-german-learning-journey/
 seo:

--- a/scripts/generate_daily_calendar_post.py
+++ b/scripts/generate_daily_calendar_post.py
@@ -555,7 +555,8 @@ def resolve_image_url(day_number: int, day_config: dict) -> str:
     if not url.startswith(prefix):
         return url
 
-    return REPO_IMAGE_POOL[(day_number - 1) % len(REPO_IMAGE_POOL)]
+    query = url.removeprefix(prefix).replace("-", ",")
+    return f"https://source.unsplash.com/featured/?{query}&sig={day_number}"
 
 
 def generate_ai_body(day_number: int, day_config: dict) -> str | None:

--- a/tests/test_generate_daily_calendar_post.py
+++ b/tests/test_generate_daily_calendar_post.py
@@ -47,11 +47,11 @@ class DailyCalendarPostTests(unittest.TestCase):
         self.assertIn("Day 21/180 CTA:", body_21)
         self.assertNotEqual(body_1, body_2)
 
-    def test_resolve_image_url_falls_back_to_repo_image_for_unsplash_search_pages(self) -> None:
+    def test_resolve_image_url_builds_source_unsplash_url_for_unsplash_search_pages(self) -> None:
         day_2 = pick_day_config(2)
         assert day_2 is not None
         image_url = resolve_image_url(2, day_2)
-        self.assertIn("raw.githubusercontent.com/learngermanghana/falowen-blog/main/photos/", image_url)
+        self.assertEqual(image_url, "https://source.unsplash.com/featured/?alphabet,letters&sig=2")
 
     def test_build_post_appends_level_test_and_standard_closing(self) -> None:
         day_1 = pick_day_config(1)


### PR DESCRIPTION
### Motivation

- Replace the previous fallback to a repository image pool for Unsplash search pages with a direct `source.unsplash.com` query to surface relevant images per-day. 
- Update a sample blog post to use an Unsplash-hosted image URL rather than the raw GitHub-hosted photo.
- Align tests with the new image-resolution behavior so automated checks validate the constructed `source.unsplash.com` URL.

### Description

- Changed `resolve_image_url` in `scripts/generate_daily_calendar_post.py` to transform Unsplash search links into `https://source.unsplash.com/featured/?{query}&sig={day_number}` using `removeprefix` and replacing hyphens with commas. 
- Removed the prior fallback to `REPO_IMAGE_POOL` for Unsplash search pages and now return the constructed `source.unsplash.com` URL. 
- Updated the example post `_posts/2026-05-10-how-falowen-supports-your-german-learning-journey.md` to use a new Unsplash image URL. 
- Adjusted `tests/test_generate_daily_calendar_post.py` to rename the test and assert the exact new `source.unsplash.com` URL.

### Testing

- Ran the unit tests with `python -m unittest` and the modified test suite `tests/test_generate_daily_calendar_post.py` completed successfully. 
- The updated test now checks `resolve_image_url(2, day_2)` equals `"https://source.unsplash.com/featured/?alphabet,letters&sig=2"` and the assertion passed. 
- Existing post-building tests that verify `## Level`, `## Quick Test`, and the standard closing continue to pass under the updated code.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0098cdf7f083218ab217049edf6421)