### PR TITLE
chore(blog): slow AI posts to biweekly

### DIFF
--- a/.github/workflows/linkedin-blog-publish.yml
+++ b/.github/workflows/linkedin-blog-publish.yml
@@ -2,7 +2,7 @@ name: Auto Post Blog Updates to LinkedIn
 
 on:
   workflow_run:
-    workflows: ["30-Day Daily Blog Auto-Publish"]
+    workflows: ["30-Day Biweekly Blog Auto-Publish"]
     types: [completed]
   workflow_dispatch:
     inputs:
@@ -28,17 +28,43 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Check biweekly publishing window
+        id: cadence
+        shell: bash
+        run: |
+          anchor_date="2026-06-03"
+
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "should_publish=true" >> "$GITHUB_OUTPUT"
+            echo "Manual dispatch requested; publishing immediately."
+            exit 0
+          fi
+
+          today=$(date -u +%F)
+          days_since_anchor=$(( ( $(date -u -d "$today" +%s) - $(date -u -d "$anchor_date" +%s) ) / 86400 ))
+
+          if [ "$days_since_anchor" -ge 0 ] && [ $((days_since_anchor % 14)) -eq 0 ]; then
+            echo "should_publish=true" >> "$GITHUB_OUTPUT"
+            echo "Biweekly LinkedIn publishing window is open for $today."
+          else
+            echo "should_publish=false" >> "$GITHUB_OUTPUT"
+            echo "Skipping LinkedIn publish for $today; cadence starts at $anchor_date and repeats every 14 days."
+          fi
+
       - name: Checkout
+        if: steps.cadence.outputs.should_publish == 'true'
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Setup Python
+        if: steps.cadence.outputs.should_publish == 'true'
         uses: actions/setup-python@v5
         with:
           python-version: "3.11"
 
       - name: Determine post path
+        if: steps.cadence.outputs.should_publish == 'true'
         id: resolve
         shell: bash
         run: |
@@ -59,7 +85,7 @@ jobs:
           echo "post_path=$target" >> "$GITHUB_OUTPUT"
 
       - name: Publish to LinkedIn
-        if: steps.resolve.outputs.skip != 'true'
+        if: steps.cadence.outputs.should_publish == 'true' && steps.resolve.outputs.skip != 'true'
         env:
           # These values are expected to be configured as GitHub Actions repository secrets.
           LINKEDIN_ACCESS_TOKEN: ${{ secrets.LINKEDIN_ACCESS_TOKEN }}

--- a/.github/workflows/weekly_blog.yml
+++ b/.github/workflows/weekly_blog.yml
@@ -1,16 +1,16 @@
-name: 30-Day Daily Blog Auto-Publish
+name: 30-Day Biweekly Blog Auto-Publish
 
 on:
   schedule:
-    # Runs daily at 09:00 UTC (09:00 Ghana time)
-    - cron: "0 9 * * *"
+    # Checks weekly at 09:00 UTC (09:00 Ghana time); the guard below only publishes every 2 weeks.
+    - cron: "0 9 * * 3"
   workflow_dispatch: {}
 
 permissions:
   contents: write
 
 concurrency:
-  group: daily-30-day-blog
+  group: biweekly-30-day-blog
   cancel-in-progress: false
 
 jobs:
@@ -27,7 +27,31 @@ jobs:
         with:
           python-version: "3.11"
 
-      - name: Generate today's calendar post
+      - name: Check biweekly publishing window
+        id: cadence
+        shell: bash
+        run: |
+          anchor_date="2026-06-03"
+
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "should_generate=true" >> "$GITHUB_OUTPUT"
+            echo "Manual dispatch requested; generating immediately."
+            exit 0
+          fi
+
+          today=$(date -u +%F)
+          days_since_anchor=$(( ( $(date -u -d "$today" +%s) - $(date -u -d "$anchor_date" +%s) ) / 86400 ))
+
+          if [ "$days_since_anchor" -ge 0 ] && [ $((days_since_anchor % 14)) -eq 0 ]; then
+            echo "should_generate=true" >> "$GITHUB_OUTPUT"
+            echo "Biweekly publishing window is open for $today."
+          else
+            echo "should_generate=false" >> "$GITHUB_OUTPUT"
+            echo "Skipping $today; next AI blog post is on the two-week cadence from $anchor_date."
+          fi
+
+      - name: Generate biweekly calendar post
+        if: steps.cadence.outputs.should_generate == 'true'
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           OPENAI_MODEL: ${{ vars.OPENAI_MODEL }}
@@ -35,6 +59,7 @@ jobs:
           python scripts/generate_daily_calendar_post.py --start-date 2026-04-15
 
       - name: Commit & push if changed
+        if: steps.cadence.outputs.should_generate == 'true'
         run: |
           git status --porcelain
           if [ -z "$(git status --porcelain)" ]; then
@@ -46,5 +71,5 @@ jobs:
           git config user.email "falowen-bot@users.noreply.github.com"
 
           git add _posts
-          git commit -m "chore(blog): daily calendar post"
+          git commit -m "chore(blog): biweekly calendar post"
           git push

--- a/workflows/daily-calendar-post.yml
+++ b/workflows/daily-calendar-post.yml
@@ -1,4 +1,4 @@
-name: Daily Calendar Blog Post PR
+name: Biweekly Calendar Blog Post PR
 
 on:
   workflow_dispatch:
@@ -12,14 +12,14 @@ on:
         required: false
         type: string
   schedule:
-    - cron: "5 5 * * *" # Daily at 05:05 UTC
+    - cron: "5 5 * * 3" # Weekly check at 05:05 UTC; guarded to create a post every 2 weeks
 
 permissions:
   contents: write
   pull-requests: write
 
 jobs:
-  create-daily-post-pr:
+  create-biweekly-post-pr:
     runs-on: ubuntu-latest
 
     steps:
@@ -51,7 +51,31 @@ jobs:
           echo "run_date=$run_date" >> "$GITHUB_OUTPUT"
           echo "start_date=$INPUT_START_DATE" >> "$GITHUB_OUTPUT"
 
-      - name: Generate daily calendar post
+      - name: Check biweekly publishing window
+        id: cadence
+        shell: bash
+        run: |
+          anchor_date="2026-06-03"
+
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "should_generate=true" >> "$GITHUB_OUTPUT"
+            echo "Manual dispatch requested; generating immediately."
+            exit 0
+          fi
+
+          run_date="${{ steps.date.outputs.run_date }}"
+          days_since_anchor=$(( ( $(date -u -d "$run_date" +%s) - $(date -u -d "$anchor_date" +%s) ) / 86400 ))
+
+          if [ "$days_since_anchor" -ge 0 ] && [ $((days_since_anchor % 14)) -eq 0 ]; then
+            echo "should_generate=true" >> "$GITHUB_OUTPUT"
+            echo "Biweekly publishing window is open for $run_date."
+          else
+            echo "should_generate=false" >> "$GITHUB_OUTPUT"
+            echo "Skipping $run_date; next AI blog post is on the two-week cadence from $anchor_date."
+          fi
+
+      - name: Generate biweekly calendar post
+        if: steps.cadence.outputs.should_generate == 'true'
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           OPENAI_MODEL: ${{ vars.OPENAI_MODEL }}
@@ -63,20 +87,21 @@ jobs:
           python scripts/generate_daily_calendar_post.py "${args[@]}"
 
       - name: Create Pull Request
+        if: steps.cadence.outputs.should_generate == 'true'
         uses: peter-evans/create-pull-request@v6
         with:
-          commit-message: "chore(blog): generate daily calendar post"
-          branch: "bot/daily-calendar-post"
+          commit-message: "chore(blog): generate biweekly calendar post"
+          branch: "bot/biweekly-calendar-post"
           delete-branch: true
-          title: "chore(blog): daily calendar auto-generated post"
+          title: "chore(blog): biweekly calendar auto-generated post"
           body: |
             ## Summary
-            - Generate the daily calendar post via `scripts/generate_daily_calendar_post.py`.
+            - Generate the biweekly calendar post via `scripts/generate_daily_calendar_post.py`.
             - Use `BLOG_TIMEZONE` repo variable (fallback: `Africa/Accra`) to determine the run date for scheduled executions.
             - Open a PR only when content changed.
 
             ## Notes
-            - Triggered daily (`5 5 * * *`) or via manual dispatch.
+            - Scheduled checks run weekly (`5 5 * * 3`), but generation is guarded to one post every 2 weeks, or via manual dispatch.
             - Manual dispatch can override `date` and `start_date`.
           labels: |
             auto-update


### PR DESCRIPTION
### Motivation
- Reduce the cadence of AI-generated calendar blog posts from daily to every two weeks to slow automatic content churn while keeping a manual dispatch option.
- Prevent social publishing when no new post was generated so LinkedIn posts don’t happen on off-cadence weeks.
- Keep the existing calendar generator script and content templates but guard automated runs with a reproducible 14-day cadence.

### Description
- Change the auto-publish workflow to a weekly check and add a 14-day cadence guard anchored at `2026-06-03`, and rename the workflow to `30-Day Biweekly Blog Auto-Publish`; generation and commit steps are gated by `steps.cadence.outputs.should_generate` (file: `.github/workflows/weekly_blog.yml`).
- Add a cadence-check step to the LinkedIn publish workflow and only run subsequent checkout/publish steps when `steps.cadence.outputs.should_publish == 'true'`, and update the workflow trigger to the renamed biweekly workflow (file: `.github/workflows/linkedin-blog-publish.yml`).
- Update the calendar-post PR workflow to run weekly checks and only create a PR on biweekly cadence, rename job/PR metadata to use "biweekly", and guard generation/PR creation with the cadence output (file: `workflows/daily-calendar-post.yml`).
- Update human-facing labels/messages and branch/commit/PR titles/descriptions to reflect the biweekly cadence and preserve manual dispatch behavior via `workflow_dispatch` in all affected flows.

### Testing
- Ran YAML validation with Ruby: `ruby -e 'require "yaml"; ARGV.each { |p| YAML.load_file(p); puts "valid yaml: #{p}" }' .github/workflows/weekly_blog.yml .github/workflows/linkedin-blog-publish.yml workflows/daily-calendar-post.yml` (result: passed).
- Ran repository diff check: `git diff --check` (result: no whitespace/errors reported).
- Ran unit tests: `python -m unittest tests.test_generate_daily_calendar_post` (result: 4 tests passed, 1 failed); the failing test asserts that generated fallback content includes a `## Level` section, but the current fallback body produced by `build_post`/`build_body` does not include that header so the test assertion fails.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1ec9c618a083219503db829ed55761)