### PR TITLE
Fix LinkedIn blog image previews

### DIFF
--- a/.github/workflows/linkedin-blog-publish.yml
+++ b/.github/workflows/linkedin-blog-publish.yml
@@ -110,11 +110,11 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       - name: Install LinkedIn image dependencies
-        if: steps.resolve.outputs.skip != 'true'
+        if: github.event_name == 'push' || steps.resolve.outputs.skip != 'true'
         run: python -m pip install --disable-pip-version-check "cairosvg>=2.7,<3"
 
       - name: Test social publisher
-        if: steps.resolve.outputs.skip != 'true'
+        if: github.event_name == 'push' || steps.resolve.outputs.skip != 'true'
         run: python -m unittest tests.test_post_to_social
 
       - name: Validate LinkedIn configuration

--- a/.github/workflows/linkedin-blog-publish.yml
+++ b/.github/workflows/linkedin-blog-publish.yml
@@ -8,6 +8,7 @@ on:
       - "_posts/*.md"
       - ".github/workflows/linkedin-blog-publish.yml"
       - "scripts/post_to_social.py"
+      - "tests/test_post_to_social.py"
       - ".github/social-publish/linkedin-baseline.txt"
   workflow_run:
     workflows: ["30-Day Biweekly Blog Auto-Publish"]
@@ -107,6 +108,14 @@ jobs:
             printf '%s\n' "${posts[@]}"
             echo "EOF"
           } >> "$GITHUB_OUTPUT"
+
+      - name: Install LinkedIn image dependencies
+        if: steps.resolve.outputs.skip != 'true'
+        run: python -m pip install --disable-pip-version-check "cairosvg>=2.7,<3"
+
+      - name: Test social publisher
+        if: steps.resolve.outputs.skip != 'true'
+        run: python -m unittest tests.test_post_to_social
 
       - name: Validate LinkedIn configuration
         if: steps.resolve.outputs.skip != 'true'

--- a/scripts/post_to_social.py
+++ b/scripts/post_to_social.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import mimetypes
 import os
 import re
 from pathlib import Path
@@ -88,7 +89,133 @@ def post_json(url: str, payload: dict, headers: dict[str, str]) -> tuple[int, st
         ) from exc
 
 
-def publish_linkedin(text: str, article_url: str, dry_run: bool) -> None:
+def get_bytes(url: str) -> tuple[bytes, str]:
+    req = request.Request(
+        url,
+        headers={
+            "User-Agent": "FalowenLinkedInPublisher/1.0",
+            "Accept": "image/jpeg,image/png,image/gif,image/svg+xml,*/*;q=0.5",
+        },
+    )
+    try:
+        with request.urlopen(req) as resp:  # noqa: S310 - image URL comes from post front matter
+            content_type = resp.headers.get_content_type() or "application/octet-stream"
+            return resp.read(), content_type
+    except error.HTTPError as exc:
+        details = exc.read().decode("utf-8", errors="replace").strip() or exc.reason
+        raise RuntimeError(
+            f"Could not download LinkedIn thumbnail from {url}: HTTP {exc.code} {details[:500]}"
+        ) from exc
+
+
+def put_bytes(url: str, data: bytes, headers: dict[str, str]) -> int:
+    req = request.Request(url, data=data, method="PUT")
+    for k, v in headers.items():
+        req.add_header(k, v)
+    try:
+        with request.urlopen(req) as resp:  # noqa: S310 - upload URL is issued by LinkedIn
+            return resp.status
+    except error.HTTPError as exc:
+        response_body = exc.read().decode("utf-8", errors="replace")
+        details = response_body.strip() or exc.reason or "No response body"
+        raise RuntimeError(
+            f"HTTP {exc.code} while uploading LinkedIn image: {details[:1200]}"
+        ) from exc
+
+
+def load_image_bytes(image_ref: str, site_url: str) -> tuple[bytes, str]:
+    if image_ref.startswith(("http://", "https://")):
+        data, content_type = get_bytes(image_ref)
+    else:
+        local_path = Path(image_ref.lstrip("/"))
+        if local_path.is_file():
+            data = local_path.read_bytes()
+            content_type = mimetypes.guess_type(local_path.name)[0] or "application/octet-stream"
+        else:
+            resolved = parse.urljoin(f"{site_url.rstrip('/')}/", image_ref)
+            data, content_type = get_bytes(resolved)
+
+    leading = data[:512].lstrip().lower()
+    is_svg = (
+        "svg" in content_type.lower()
+        or parse.urlparse(image_ref).path.lower().endswith(".svg")
+        or b"<svg" in leading
+    )
+    if is_svg:
+        try:
+            import cairosvg
+        except ImportError as exc:  # pragma: no cover - dependency is installed in GitHub Actions
+            raise RuntimeError(
+                "SVG LinkedIn thumbnails require CairoSVG. Install it with `pip install cairosvg`."
+            ) from exc
+        data = cairosvg.svg2png(bytestring=data)
+        content_type = "image/png"
+
+    allowed_types = {"image/jpeg", "image/png", "image/gif"}
+    if content_type.lower() not in allowed_types:
+        raise RuntimeError(
+            f"LinkedIn thumbnail format is unsupported: {content_type}. Use JPG, PNG, GIF, or SVG."
+        )
+
+    return data, content_type.lower()
+
+
+def linkedin_headers(token: str, linkedin_version: str) -> dict[str, str]:
+    return {
+        "Authorization": f"Bearer {token}",
+        "X-Restli-Protocol-Version": "2.0.0",
+        "Linkedin-Version": linkedin_version,
+    }
+
+
+def upload_linkedin_image(
+    image_ref: str,
+    site_url: str,
+    token: str,
+    author_urn: str,
+    linkedin_version: str,
+) -> str:
+    headers = linkedin_headers(token, linkedin_version)
+    status, body = post_json(
+        "https://api.linkedin.com/rest/images?action=initializeUpload",
+        {"initializeUploadRequest": {"owner": author_urn}},
+        headers,
+    )
+    if status != 200:
+        raise RuntimeError(f"LinkedIn image upload initialization failed with status {status}.")
+
+    try:
+        value = json.loads(body)["value"]
+        upload_url = value["uploadUrl"]
+        image_urn = value["image"]
+    except (KeyError, TypeError, json.JSONDecodeError) as exc:
+        raise RuntimeError(f"LinkedIn image upload returned an unexpected response: {body[:500]}") from exc
+
+    image_bytes, content_type = load_image_bytes(image_ref, site_url)
+    upload_status = put_bytes(
+        upload_url,
+        image_bytes,
+        {
+            "Authorization": f"Bearer {token}",
+            "Content-Type": content_type,
+        },
+    )
+    if upload_status not in {200, 201}:
+        raise RuntimeError(f"LinkedIn image upload failed with status {upload_status}.")
+
+    return image_urn
+
+
+def publish_linkedin(
+    text: str,
+    article_url: str,
+    dry_run: bool,
+    *,
+    title: str | None = None,
+    description: str | None = None,
+    image_url: str | None = None,
+    site_url: str = "https://blog.falowen.app",
+) -> None:
     token = env_value("LINKEDIN_ACCESS_TOKEN")
     author_urn = env_value("LINKEDIN_AUTHOR_URN", "LINKEDIN_PERSON_URN")
     if not token or not author_urn:
@@ -100,7 +227,7 @@ def publish_linkedin(text: str, article_url: str, dry_run: bool) -> None:
 
     linkedin_version = env_value("LINKEDIN_VERSION") or "202607"
     commentary = f"{text}\n\nRead more: {article_url}"
-    payload = {
+    payload: dict = {
         "author": author_urn,
         "commentary": commentary,
         "visibility": "PUBLIC",
@@ -112,6 +239,25 @@ def publish_linkedin(text: str, article_url: str, dry_run: bool) -> None:
         "lifecycleState": "PUBLISHED",
         "isReshareDisabledByAuthor": False,
     }
+
+    # LinkedIn's Posts API does not scrape URLs for article previews. We must
+    # explicitly send article metadata and upload the thumbnail image first.
+    if title or description or image_url:
+        article: dict[str, str] = {
+            "source": article_url,
+            "title": title or text.splitlines()[0][:200],
+            "description": description or "",
+        }
+        if image_url and not dry_run:
+            article["thumbnail"] = upload_linkedin_image(
+                image_url,
+                site_url,
+                token,
+                author_urn,
+                linkedin_version,
+            )
+        payload["content"] = {"article": article}
+
     if dry_run:
         print("[linkedin] Dry run: would publish post")
         return
@@ -119,11 +265,7 @@ def publish_linkedin(text: str, article_url: str, dry_run: bool) -> None:
     status, body = post_json(
         "https://api.linkedin.com/rest/posts",
         payload,
-        {
-            "Authorization": f"Bearer {token}",
-            "X-Restli-Protocol-Version": "2.0.0",
-            "Linkedin-Version": linkedin_version,
-        },
+        linkedin_headers(token, linkedin_version),
     )
     print(f"[linkedin] Published (status={status}): {body[:160]}")
 
@@ -214,7 +356,15 @@ def main() -> int:
 
     url = post_url(args.site_url, post_path, fm)
 
-    publish_linkedin(f"{title}\n\n{excerpt}", url, args.dry_run)
+    publish_linkedin(
+        f"{title}\n\n{excerpt}",
+        url,
+        args.dry_run,
+        title=title,
+        description=excerpt,
+        image_url=image_url,
+        site_url=args.site_url,
+    )
     if args.linkedin_only:
         return 0
 

--- a/tests/test_post_to_social.py
+++ b/tests/test_post_to_social.py
@@ -64,6 +64,54 @@ class PublishLinkedInTests(unittest.TestCase):
         {
             "LINKEDIN_ACCESS_TOKEN": "token",
             "LINKEDIN_AUTHOR_URN": "urn:li:person:author",
+        },
+        clear=True,
+    )
+    @patch("scripts.post_to_social.upload_linkedin_image")
+    @patch("scripts.post_to_social.post_json")
+    def test_publish_linkedin_adds_article_thumbnail(
+        self,
+        mock_post_json,
+        mock_upload_linkedin_image,
+    ) -> None:
+        mock_post_json.return_value = (201, "")
+        mock_upload_linkedin_image.return_value = "urn:li:image:thumbnail"
+
+        publish_linkedin(
+            "German lesson",
+            "https://blog.falowen.app/german-lesson/",
+            dry_run=False,
+            title="German Lesson",
+            description="Learn a useful German grammar topic.",
+            image_url="/assets/img/german-lesson.svg",
+            site_url="https://blog.falowen.app",
+        )
+
+        mock_upload_linkedin_image.assert_called_once_with(
+            "/assets/img/german-lesson.svg",
+            "https://blog.falowen.app",
+            "token",
+            "urn:li:person:author",
+            "202607",
+        )
+        payload = mock_post_json.call_args.args[1]
+        self.assertEqual(
+            {
+                "article": {
+                    "source": "https://blog.falowen.app/german-lesson/",
+                    "thumbnail": "urn:li:image:thumbnail",
+                    "title": "German Lesson",
+                    "description": "Learn a useful German grammar topic.",
+                }
+            },
+            payload["content"],
+        )
+
+    @patch.dict(
+        "os.environ",
+        {
+            "LINKEDIN_ACCESS_TOKEN": "token",
+            "LINKEDIN_AUTHOR_URN": "urn:li:person:author",
             "LINKEDIN_VERSION": "202606",
         },
         clear=True,
@@ -104,7 +152,13 @@ class PublishLinkedInTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as temp_dir:
             post_path = Path(temp_dir) / "2026-07-24-test-post.md"
             post_path.write_text(
-                "---\ntitle: Test Post\npermalink: /test-post/\n---\nUseful body text.",
+                "---\n"
+                "title: Test Post\n"
+                "excerpt: A useful test excerpt.\n"
+                "image: /assets/img/test.svg\n"
+                "permalink: /test-post/\n"
+                "---\n"
+                "Useful body text.",
                 encoding="utf-8",
             )
             with patch(
@@ -114,7 +168,15 @@ class PublishLinkedInTests(unittest.TestCase):
                 result = main()
 
         self.assertEqual(0, result)
-        mock_linkedin.assert_called_once()
+        mock_linkedin.assert_called_once_with(
+            "Test Post\n\nA useful test excerpt.",
+            "https://falowen.com/test-post/",
+            False,
+            title="Test Post",
+            description="A useful test excerpt.",
+            image_url="/assets/img/test.svg",
+            site_url="https://falowen.com",
+        )
         mock_instagram.assert_not_called()
         mock_medium.assert_not_called()
 


### PR DESCRIPTION
## What changed

- Upload each blog post thumbnail through LinkedIn's Images API before publishing.
- Send an explicit `content.article` payload with source URL, title, description, and thumbnail URN.
- Resolve both external images and repository-relative images.
- Convert repository SVG artwork to PNG before upload because LinkedIn accepts raster thumbnail formats.
- Add regression tests and run the social-publisher tests on relevant pushes.

## Root cause

The publisher sent only `commentary` plus a URL. LinkedIn's current Posts API does not scrape article URLs when API partners create posts, so the post was created successfully but without an image/article preview.

## Expected result

New Falowen LinkedIn blog posts should render with their article thumbnail instead of the blank preview area.