### PR TITLE
Repost LinkedIn blog posts with image previews

### DIFF
--- a/.github/social-publish/linkedin-shared-posts.txt
+++ b/.github/social-publish/linkedin-shared-posts.txt
@@ -1,6 +1,1 @@
 # Successfully shared LinkedIn blog post paths, one per line.
-_posts/2026-07-24-german-adjective-endings-made-simple.md
-_posts/2026-07-24-german-connectors-weil-obwohl-deshalb-trotzdem-b1.md
-_posts/2026-07-24-german-separable-verbs-for-beginners.md
-_posts/2026-07-25-german-konjunktiv-ii-politeness-wishes-advice.md
-_posts/2026-07-26-german-relative-clauses-relativsaetze-b1.md

--- a/.github/workflows/linkedin-blog-publish.yml
+++ b/.github/workflows/linkedin-blog-publish.yml
@@ -10,6 +10,7 @@ on:
       - "scripts/post_to_social.py"
       - "tests/test_post_to_social.py"
       - ".github/social-publish/linkedin-baseline.txt"
+      - ".github/social-publish/linkedin-shared-posts.txt"
   workflow_run:
     workflows: ["30-Day Biweekly Blog Auto-Publish"]
     types: [completed]


### PR DESCRIPTION
## What changed

- Reset the LinkedIn shared-post ledger so the five deleted LinkedIn blog posts are queued for publishing again.
- Add the shared-post ledger to the LinkedIn workflow push paths, so an intentional ledger reset triggers the publisher immediately.

## Why

The previous LinkedIn posts were deleted after the image-preview bug was fixed. Reposting now will use the updated publisher that uploads each article thumbnail and attaches it to the LinkedIn article preview.

## Posts queued

- German Adjective Endings
- German Connectors: weil, obwohl, deshalb, trotzdem
- German Separable Verbs
- German Konjunktiv II
- German Relative Clauses
