### PR TITLE
Fix WhatsApp contact number

### DIFF
--- a/_includes/lead-capture.html
+++ b/_includes/lead-capture.html
@@ -5,7 +5,7 @@
     <p>Join the Learn Language Education Academy community for practical study guidance, A1–C1 class updates and Falowen learning resources.</p>
   </div>
   <div class="lead-actions">
-    <a class="btn-primary" href="https://wa.me/233541588913?text=Hello%20Learn%20Language%20Education%20Academy%2C%20I%20want%20German%20class%20updates" target="_blank" rel="noopener">Chat on WhatsApp</a>
+    <a class="btn-primary" href="https://wa.me/233205706589?text=Hello%20Learn%20Language%20Education%20Academy%2C%20I%20want%20German%20class%20updates" target="_blank" rel="noopener">Chat on WhatsApp</a>
     <a class="btn-secondary" href="https://www.learngermanghana.com/classes" target="_blank" rel="noopener">View upcoming classes</a>
   </div>
 </section>

--- a/contact.md
+++ b/contact.md
@@ -9,7 +9,7 @@ permalink: /contact/
 We're here to help with course registrations, class details, and general inquiries.
 
 - **Email:** [learngermanghana@gmail.com](mailto:learngermanghana@gmail.com)
-- **Phone:** [0205706589](tel:+233205706589)
+- **Phone:** [233205706589](tel:+233205706589)
 - **Mailing Address:** P.O. Box 2624, Kaneshie
 
 ## Hours of Operation


### PR DESCRIPTION
## What changed

- Replaced the blog's WhatsApp lead link from `233541588913` to `233205706589`.
- Standardized the visible phone number on the Contact page to `233205706589`; its telephone link already pointed to this number.

## Scope checked

I also checked the main contact-related blog files, including the footer, CTA, home layout, author box, and site config. No other contact phone/WhatsApp number was present there.