### PR TITLE
Fix unreliable LinkedIn thumbnail source

### DIFF
--- a/_posts/2026-07-29-how-to-ask-simple-questions-in-german.md
+++ b/_posts/2026-07-29-how-to-ask-simple-questions-in-german.md
@@ -5,7 +5,7 @@ date: 2026-07-29
 tags: [falowen, german, 30-day-blog, how-to-ask-simple-questions-in-german]
 categories: [Speaking Practice]
 excerpt: "Learn how to ask simple questions in German using common question words."
-image: https://source.unsplash.com/featured/?student,raising,hand&sig=106
+image: /assets/img/falowen-blog-default.svg
 image_alt: "How to Ask Simple Questions in German"
 permalink: /how-to-ask-simple-questions-in-german/
 seo:

--- a/scripts/generate_daily_calendar_post.py
+++ b/scripts/generate_daily_calendar_post.py
@@ -555,8 +555,11 @@ def resolve_image_url(day_number: int, day_config: dict) -> str:
     if not url.startswith(prefix):
         return url
 
-    query = url.removeprefix(prefix).replace("-", ",")
-    return f"https://source.unsplash.com/featured/?{query}&sig={day_number}"
+    # Unsplash search pages are useful editorial references, but the former
+    # source.unsplash.com endpoint is not a dependable image host. Use a local
+    # asset so generated posts and social publishing never depend on that
+    # transient service.
+    return "/assets/img/falowen-blog-default.svg"
 
 
 def generate_ai_body(day_number: int, day_config: dict) -> str | None:

--- a/tests/test_generate_daily_calendar_post.py
+++ b/tests/test_generate_daily_calendar_post.py
@@ -47,11 +47,21 @@ class DailyCalendarPostTests(unittest.TestCase):
         self.assertIn("Day 21/180 CTA:", body_21)
         self.assertNotEqual(body_1, body_2)
 
-    def test_resolve_image_url_builds_source_unsplash_url_for_unsplash_search_pages(self) -> None:
+    def test_resolve_image_url_uses_local_fallback_for_unsplash_search_pages(self) -> None:
         day_2 = pick_day_config(2)
         assert day_2 is not None
         image_url = resolve_image_url(2, day_2)
-        self.assertEqual(image_url, "https://source.unsplash.com/featured/?alphabet,letters&sig=2")
+        self.assertEqual(image_url, "/assets/img/falowen-blog-default.svg")
+
+    def test_resolve_image_url_preserves_explicit_image_url(self) -> None:
+        image_url = resolve_image_url(
+            2,
+            {
+                "image_url": "/assets/img/german-alphabet-complete-beginners.svg",
+                "unsplash_link": "https://unsplash.com/s/photos/alphabet-letters",
+            },
+        )
+        self.assertEqual(image_url, "/assets/img/german-alphabet-complete-beginners.svg")
 
     def test_build_post_appends_level_test_and_standard_closing(self) -> None:
         day_1 = pick_day_config(1)


### PR DESCRIPTION
### Motivation

- Replace the transient `source.unsplash.com` image references because the endpoint is unreliable and causes LinkedIn publishing to fail with HTTP 503 errors. 
- Ensure generated daily-calendar posts and social publishing do not depend on an external, flaky image host.

### Description

- Change `resolve_image_url` in `scripts/generate_daily_calendar_post.py` to return the repository local fallback image `/assets/img/falowen-blog-default.svg` for Unsplash search pages while preserving any explicit `image_url` provided. 
- Update `_posts/2026-07-29-how-to-ask-simple-questions-in-german.md` front matter to use the local fallback image instead of a `source.unsplash.com` URL. 
- Add and adjust unit tests in `tests/test_generate_daily_calendar_post.py` to assert the new local-fallback behavior and to verify explicit image overrides remain unchanged. 

### Testing

- Ran targeted unit tests with `python -m unittest tests.test_generate_daily_calendar_post.DailyCalendarPostTests.test_resolve_image_url_uses_local_fallback_for_unsplash_search_pages tests.test_generate_daily_calendar_post.DailyCalendarPostTests.test_resolve_image_url_preserves_explicit_image_url tests.test_post_to_social` and they passed. 
- Ran full test discovery with `python -m unittest discover -s tests -v` and `python -m compileall -q scripts tests`; compilation and most tests passed, but the repository already had an unrelated failing test (`test_build_post_appends_level_test_and_standard_closing`) that expects a `## Level` heading not present in the generated day-one post. 
- Verified `git diff --check` produced no whitespace or diff errors. 

Notes: local SVG-to-PNG conversion could not be exercised here because `cairosvg` is not installed in this container, however the CI workflow installs `cairosvg` before publishing so runtime conversion will be available in the LinkedIn publishing pipeline.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6b6f80bcbc8321a3ec43047fc94760)