### PR TITLE
Fix topic layout Liquid syntax for GitHub Pages

### DIFF
--- a/_layouts/topic.html
+++ b/_layouts/topic.html
@@ -12,9 +12,15 @@ layout: default
   </div>
 </section>
 
-{% assign topic_posts = site.posts | where_exp: 'post', 'post.tags contains page.topic or post.categories contains page.topic or post.title contains page.topic' %}
+{% assign tagged_posts = site.posts | where_exp: 'post', 'post.tags contains page.topic' %}
+{% assign categorized_posts = site.posts | where_exp: 'post', 'post.categories contains page.topic' %}
+{% assign titled_posts = site.posts | where_exp: 'post', 'post.title contains page.topic' %}
+{% assign topic_posts = tagged_posts | concat: categorized_posts | concat: titled_posts | uniq %}
 {% if topic_posts.size == 0 and page.alt_topic %}
-  {% assign topic_posts = site.posts | where_exp: 'post', 'post.tags contains page.alt_topic or post.categories contains page.alt_topic or post.title contains page.alt_topic' %}
+  {% assign tagged_posts = site.posts | where_exp: 'post', 'post.tags contains page.alt_topic' %}
+  {% assign categorized_posts = site.posts | where_exp: 'post', 'post.categories contains page.alt_topic' %}
+  {% assign titled_posts = site.posts | where_exp: 'post', 'post.title contains page.alt_topic' %}
+  {% assign topic_posts = tagged_posts | concat: categorized_posts | concat: titled_posts | uniq %}
 {% endif %}
 
 <section class="archive-grid topic-grid">


### PR DESCRIPTION
### Motivation
- The previous `_layouts/topic.html` used a compound `where_exp` with boolean `or` expressions which caused Liquid parse errors on the GitHub Pages/Jekyll environment.
- The change aims to make the topic filtering logic compatible with the GitHub Pages Liquid/Jekyll runtime while preserving tag, category, and title matching semantics.

### Description
- Replaced the single compound filter with three separate `where_exp` queries for tags, categories, and title matching and combined them using `concat` and `uniq` into `topic_posts` in `_layouts/topic.html`.
- Applied the same non-compound filtering approach to the `page.alt_topic` fallback so alternate-topic pages behave the same way.

### Testing
- Ran `git diff --check` to validate the working tree and it passed. 
- Verified the layout no longer contains compound boolean expressions by checking the file for `where_exp` boolean operators. 
- Ran `bundle check` but it could not complete because `rubygems.org` returned HTTP 403 in the environment. 
- Attempted a Docker-based GitHub Pages build but it could not run because Docker is not available in the environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6b712fa204832180a7d7be01f4abb8)